### PR TITLE
SLT-387: options implementation using extra_conditions

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -87,8 +87,6 @@ data:
                                                                               
         include fastcgi.conf;
 
-        {{ include "frontend.basicauth" . | indent 6}}
-         
         location = /robots.txt {
           access_log off;
           {{- if not .Values.nginx.robotsTxt.allow }}
@@ -97,54 +95,60 @@ data:
           {{- end}}
         } 
 
-        ## Most sites won't have configured favicon
-        ## and since its always grabbed, turn it off in access log
-        ## and turn off it's not-found error in the error log
-        location = /favicon.ico { access_log off; log_not_found off;  }
-
-        ## Same for apple-touch-icon files
-        location = /apple-touch-icon.png { access_log off; log_not_found off; }
-        location = /apple-touch-icon-precomposed.png { access_log off; log_not_found off; }
-
-        ## Rather than just denying .ht* in the config, why not deny
-        ## access to all .invisible files
-        location ~ /\. { return 404; access_log off; log_not_found off; }
-
         {{- range $index, $service := .Values.services }}
         {{ if default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}
         location {{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }} {
             
-            # Pass the request on to frontend.
-            proxy_pass http://{{ $.Release.Name }}-{{ $index }}:{{ default $.Values.serviceDefaults.port $service.port }}{{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }};
+          {{ if $.Values.nginx.extra_conditions }}
+          {{ $.Values.nginx.extra_conditions | nindent 10 }}
+          {{- end}}
 
-            # We expect the downsteam servers to redirect to the
-            # right hostname, so don't do any rewrites here.
-            proxy_redirect             off;
+          {{ include "frontend.basicauth" $ | indent 6}}
+          
+          ## Most sites won't have configured favicon
+          ## and since its always grabbed, turn it off in access log
+          ## and turn off it's not-found error in the error log
+          location = {{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}/favicon.ico { access_log off; log_not_found off;  }
 
-            proxy_connect_timeout  180s;
-            proxy_send_timeout  180s;
-            proxy_read_timeout  180s;
+          ## Same for apple-touch-icon files
+          location = {{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}/apple-touch-icon.png { access_log off; log_not_found off; }
+          location = {{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}/apple-touch-icon-precomposed.png { access_log off; log_not_found off; }
 
-            # Let's increase the buffer size
-            proxy_buffer_size   512k;
-            proxy_buffers   16 512k;
-            proxy_busy_buffers_size   512k;
+          ## Rather than just denying .ht* in the config, why not deny
+          ## access to all .invisible files
+          location ~ /\. { return 404; access_log off; log_not_found off; }
 
-            # Pass a bunch of headers to the downstream server
-            # so they'll know what's going on.
-            proxy_set_header           Host             $host;
-            proxy_set_header           X-Real-IP        $remote_addr;
-            proxy_set_header           X-Forwarded-For  $proxy_add_x_forwarded_for;
+          # Pass the request on to frontend.
+          proxy_pass http://{{ $.Release.Name }}-{{ $index }}:{{ default $.Values.serviceDefaults.port $service.port }}{{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }};
 
-            # Most web apps can be configured to read this header and
-            # understand that the current session is actually HTTPS.
-            proxy_set_header        X-Forwarded-Proto $scheme;
-            proxy_set_header        X-Forwarded-Port  $server_port;
-            add_header              Front-End-Https   on;
-            
-            {{- range $header_name, $header_value := $.Values.nginx.extra_headers }}
-            add_header {{ $header_name }} {{ $header_value }};
-            {{- end }}
+          # We expect the downsteam servers to redirect to the
+          # right hostname, so don't do any rewrites here.
+          proxy_redirect             off;
+
+          proxy_connect_timeout  180s;
+          proxy_send_timeout  180s;
+          proxy_read_timeout  180s;
+
+          # Let's increase the buffer size
+          proxy_buffer_size   512k;
+          proxy_buffers   16 512k;
+          proxy_busy_buffers_size   512k;
+
+          # Pass a bunch of headers to the downstream server
+          # so they'll know what's going on.
+          proxy_set_header           Host             $host;
+          proxy_set_header           X-Real-IP        $remote_addr;
+          proxy_set_header           X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+          # Most web apps can be configured to read this header and
+          # understand that the current session is actually HTTPS.
+          proxy_set_header        X-Forwarded-Proto $scheme;
+          proxy_set_header        X-Forwarded-Port  $server_port;
+          add_header              Front-End-Https   on;
+          
+          {{- range $header_name, $header_value := $.Values.nginx.extra_headers }}
+          add_header {{ $header_name }} {{ $header_value }};
+          {{- end }}
         }    
         {{- end }}
         {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -87,6 +87,17 @@ nginx:
 
   extra_headers: {}
 
+  extra_conditions: ""
+    # |
+    # # need this for node OPTIONS requests to work while site has bauth
+    # add_header 'Access-Control-Allow-Methods' 'GET,OPTIONS,PUT,DELETE,POST' always;
+    # add_header 'Access-Control-Allow-Credentials' 'true' always;
+    # add_header 'Access-Control-Allow-Origin' '$http_origin' always;
+    # add_header 'Access-Control-Allow-Headers' 'Authorization,DNT,User-Agent,Keep-Alive,Content-Type,accept,origin,X-Requested-With,Access-Control-Allow-Origin' always;
+    # if ($request_method = OPTIONS ) {
+    #   return 204;
+    # }
+
 services:
   # frontend:
   #   image: 'you need to pass in a value for frontend.image to your helm chart'

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -4,6 +4,17 @@
 # See https://github.com/wunderio/charts/blob/master/frontend/values.yaml
 # for all possible options.
 
+nginx:
+  extra_conditions: |
+    # Response to OPTIONS requests
+    add_header 'Access-Control-Allow-Methods' 'GET,OPTIONS,PUT,DELETE,POST' always;
+    add_header 'Access-Control-Allow-Credentials' 'true' always;
+    add_header 'Access-Control-Allow-Origin' '$http_origin' always;
+    add_header 'Access-Control-Allow-Headers' 'Authorization,DNT,User-Agent,Keep-Alive,Content-Type,accept,origin,X-Requested-With,Access-Control-Allow-Origin' always;
+    if ($request_method = OPTIONS ) {
+      return 204;
+    }
+
 services: 
   hello:
     exposedRoute: '/hello'

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -4,17 +4,6 @@
 # See https://github.com/wunderio/charts/blob/master/frontend/values.yaml
 # for all possible options.
 
-nginx:
-  extra_conditions: |
-    # Response to OPTIONS requests
-    add_header 'Access-Control-Allow-Methods' 'GET,OPTIONS,PUT,DELETE,POST' always;
-    add_header 'Access-Control-Allow-Credentials' 'true' always;
-    add_header 'Access-Control-Allow-Origin' '$http_origin' always;
-    add_header 'Access-Control-Allow-Headers' 'Authorization,DNT,User-Agent,Keep-Alive,Content-Type,accept,origin,X-Requested-With,Access-Control-Allow-Origin' always;
-    if ($request_method = OPTIONS ) {
-      return 204;
-    }
-
 services: 
   hello:
     exposedRoute: '/hello'


### PR DESCRIPTION
Hello app works with correct credentials:
```
➜  ~ curl -u "silta:simplepass" https://feature-slt-387-options.frontend-project-k8s.silta.wdr.io/hello -I
HTTP/2 200 
access-control-allow-credentials: true
access-control-allow-headers: Authorization,DNT,User-Agent,Keep-Alive,Content-Type,accept,origin,X-Requested-With,Access-Control-Allow-Origin
access-control-allow-methods: GET,OPTIONS,PUT,DELETE,POST
content-type: text/html; charset=utf-8
date: Fri, 08 Nov 2019 15:17:43 GMT
etag: W/"5-9/+ei3uy4Jtwk1pdeF4MxdnQq/A"
front-end-https: on
server: nginx
vary: Accept-Encoding
x-powered-by: Express
content-length: 5
```

World app works with correct credentials:
```
➜  ~ curl -u "silta:simplepass" https://feature-slt-387-options.frontend-project-k8s.silta.wdr.io/world -I
HTTP/2 200 
access-control-allow-credentials: true
access-control-allow-headers: Authorization,DNT,User-Agent,Keep-Alive,Content-Type,accept,origin,X-Requested-With,Access-Control-Allow-Origin
access-control-allow-methods: GET,OPTIONS,PUT,DELETE,POST
content-type: text/html; charset=utf-8
date: Fri, 08 Nov 2019 15:17:48 GMT
etag: W/"5-cMB+wY74nFMJu7CTfzpjQkEeH90"
front-end-https: on
server: nginx
vary: Accept-Encoding
x-powered-by: Express
content-length: 5
```

Nonexistent url with correct credentials:
```
➜  ~ curl -u "silta:simplepass" https://feature-slt-387-options.frontend-project-k8s.silta.wdr.io/worl -I 
HTTP/2 404 
content-type: text/html
date: Fri, 08 Nov 2019 15:17:51 GMT
server: nginx
vary: Accept-Encoding
content-length: 146
```

OPTIONS request with correct credentials returns headers only and http status 204 (no content)
```
➜  ~ curl -u "silta:simplepass" https://feature-slt-387-options.frontend-project-k8s.silta.wdr.io/hello -I -X OPTIONS
HTTP/2 204 
access-control-allow-credentials: true
access-control-allow-headers: Authorization,DNT,User-Agent,Keep-Alive,Content-Type,accept,origin,X-Requested-With,Access-Control-Allow-Origin
access-control-allow-methods: GET,OPTIONS,PUT,DELETE,POST
date: Fri, 08 Nov 2019 15:18:04 GMT
front-end-https: on
server: nginx
vary: Accept-Encoding
```

OPTIONS request with incorrect / no credentials returns headers only and http status 204 (no content):
```
➜  ~ curl https://feature-slt-387-options.frontend-project-k8s.silta.wdr.io/hello -I -X OPTIONS            
HTTP/2 204 
access-control-allow-credentials: true
access-control-allow-headers: Authorization,DNT,User-Agent,Keep-Alive,Content-Type,accept,origin,X-Requested-With,Access-Control-Allow-Origin
access-control-allow-methods: GET,OPTIONS,PUT,DELETE,POST
date: Fri, 08 Nov 2019 15:18:10 GMT
front-end-https: on
server: nginx
vary: Accept-Encoding
```