### PR TITLE
SLT-389: Add support for volumes

### DIFF
--- a/chart/templates/services-cron.yaml
+++ b/chart/templates/services-cron.yaml
@@ -21,6 +21,16 @@ spec:
           containers:
           - name: {{ $index }}-cron
             image: {{ $service.image | quote }}
+            volumeMounts:
+              {{ if $service.mounts }}
+              {{- range $index, $mountName := $service.mounts -}}
+              {{ $mount := (index $.Values.mounts $mountName) }}
+              {{- if eq $mount.enabled true }}
+              - name: frontend-{{ $mountName }}
+                mountPath: {{ $mount.mountPath }}
+              {{- end }}
+              {{- end }}
+              {{- end }}
             env:
             {{- range $key, $val := $service.env }}
             - name: {{ $key }}
@@ -37,6 +47,17 @@ spec:
               {{ else -}}
               {{ $.Values.serviceDefaults.resources | toYaml | nindent 14 }}
               {{- end }}
+          volumes:
+            {{ if $service.mounts }}
+            {{- range $index, $mountName := $service.mounts -}}
+            {{ $mount := (index $.Values.mounts $mountName) }}
+            {{- if eq $mount.enabled true }}
+            - name: frontend-{{ $mountName }}
+              persistentVolumeClaim:
+                claimName: {{ $.Release.Name }}-{{ $mountName }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
           restartPolicy: OnFailure
 ---
 {{- end }}

--- a/chart/templates/services-deployment.yaml
+++ b/chart/templates/services-deployment.yaml
@@ -28,7 +28,7 @@ spec:
           {{- range $index, $mountName := $service.mounts -}}
           {{ $mount := (index $.Values.mounts $mountName) }}
           {{- if eq $mount.enabled true }}
-          - name: frontend-{{ $index }}
+          - name: frontend-{{ $mountName }}
             mountPath: {{ $mount.mountPath }}
           {{- end }}
           {{- end }}
@@ -61,9 +61,9 @@ spec:
         {{- range $index, $mountName := $service.mounts -}}
         {{ $mount := (index $.Values.mounts $mountName) }}
         {{- if eq $mount.enabled true }}
-        - name: frontend-{{ $index }}
+        - name: frontend-{{ $mountName }}
           persistentVolumeClaim:
-            claimName: {{ $.Release.Name }}-{{ $index }}
+            claimName: {{ $.Release.Name }}-{{ $mountName }}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/chart/templates/services-deployment.yaml
+++ b/chart/templates/services-deployment.yaml
@@ -61,7 +61,7 @@ spec:
         {{- range $index, $mountName := $service.mounts -}}
         {{ $mount := (index $.Values.mounts $mountName) }}
         {{- if eq $mount.enabled true }}
-        - name: drupal-{{ $index }}
+        - name: frontend-{{ $index }}
           persistentVolumeClaim:
             claimName: {{ $.Release.Name }}-{{ $index }}
         {{- end }}

--- a/chart/templates/services-deployment.yaml
+++ b/chart/templates/services-deployment.yaml
@@ -24,6 +24,15 @@ spec:
         - containerPort: {{ default $.Values.serviceDefaults.port $service.port }}
           name: {{ $index }}
         volumeMounts:
+          {{ if $service.mounts }}
+          {{- range $index, $mountName := $service.mounts -}}
+          {{ $mount := (index $.Values.mounts $mountName) }}
+          {{- if eq $mount.enabled true }}
+          - name: frontend-{{ $index }}
+            mountPath: {{ $mount.mountPath }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
         livenessProbe:
           tcpSocket:
             port: {{ default $.Values.serviceDefaults.port $service.port }}
@@ -47,6 +56,17 @@ spec:
           {{ else -}}
           {{ $.Values.serviceDefaults.resources | toYaml | nindent 10 }}
           {{- end }}
+      volumes:
+        {{ if $service.mounts }}
+        {{- range $index, $mountName := $service.mounts -}}
+        {{ $mount := (index $.Values.mounts $mountName) }}
+        {{- if eq $mount.enabled true }}
+        - name: drupal-{{ $index }}
+          persistentVolumeClaim:
+            claimName: {{ $.Release.Name }}-{{ $index }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
 
 {{- if $service.autoscaling }}
 {{- if $service.autoscaling.enabled }}

--- a/chart/templates/volumes.yaml
+++ b/chart/templates/volumes.yaml
@@ -1,0 +1,46 @@
+{{- range $index, $mount := .Values.mounts }}
+{{- if $mount.enabled }}
+{{- if eq $mount.storageClassName "silta-shared" }}
+# Mount-enabled: {{ $mount.enabled  }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ $.Release.Name }}-{{ $index }}
+  labels:
+    name: {{ $.Release.Name }}-{{ $index }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: {{ $mount.storage }}
+  storageClassName: {{ $mount.storageClassName }}
+  {{- if $mount.csiDriverName }}
+  csi:
+    driver: {{ $mount.csiDriverName }}
+    volumeHandle: {{ $.Release.Name }}-{{ $index }}
+    volumeAttributes:
+      remotePathSuffix: /{{ $.Release.Namespace }}/{{ $.Values.environmentName }}/{{ $index }}
+  {{- end }}
+---
+{{- end }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $.Release.Name }}-{{ $index }}
+  labels:
+    {{- include "frontend.release_labels" $ | nindent 4 }}
+spec:
+  storageClassName: {{ $mount.storageClassName }}
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ $mount.storage }}
+{{- if eq $mount.storageClassName "silta-shared" }}
+  selector:
+    matchLabels:
+      name: {{ $.Release.Name }}-{{ $index }}
+{{- end }}
+---
+{{- end -}}
+{{- end }}

--- a/chart/tests/volumes_test.yaml
+++ b/chart/tests/volumes_test.yaml
@@ -1,0 +1,21 @@
+suite: drupal volumes
+templates:
+  - volumes.yaml
+tests:
+  - it: public files volume should be configurable
+    set:
+      mounts:
+        example-files:
+          enabled: true
+          storage: 123Gi
+          storageClassName: silta-shared
+
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.storageClassName
+          value: silta-shared
+      - documentIndex: 1
+        equal:
+          path: spec.resources.requests.storage
+          value: 123Gi

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -138,6 +138,15 @@ cron:
 #    command: echo "hello world"
 #    schedule: "~ 1 * * *"
 
+# Configure the dynamically mounted volumes
+mounts:
+#  files:
+#    enabled: true
+#    storage: 1G
+#    mountPath: /app/files
+#    storageClassName: silta-shared
+#    csiDriverName: csi-rclone
+
 # Provide defaults for all services.
 # Note that only keys used here can be overridden.
 serviceDefaults:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -20,7 +20,7 @@ services:
 
 cron:
   hello-cli:
-    service: hello
+    service: world
     command: echo $(date) > /app/files/lastupdate.txt
     schedule: "~ * * * *"
 

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -21,7 +21,7 @@ services:
 cron:
   hello-cli:
     service: hello
-    command: echo "Hello, again"
+    command: echo $(date) > /app/files/lastupdate.txt
     schedule: "~ * * * *"
 
 mounts:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -15,9 +15,19 @@ services:
     exposedRoute: '/world'
     port: 5000
     replicas: 2
+    mounts:
+      - files
 
 cron:
   hello-cli:
     service: hello
     command: echo "Hello, again"
     schedule: "~ * * * *"
+
+mounts:
+  files:
+    enabled: true
+    storage: 1G
+    mountPath: /app/files
+    storageClassName: silta-shared
+    csiDriverName: csi-rclone

--- a/world/server.js
+++ b/world/server.js
@@ -2,6 +2,8 @@ const express = require('express')
 const app = express()
 const port = parseInt(process.env.PORT, 10) || 3000;
 
-app.get('/world', (req, res) => res.send('World'))
+app.get('/world', (req, res) => res.send('World'));
 
-app.listen(port, () => console.log(`Example app listening on port ${port}!`))
+app.use('/world/files', express.static('files'));
+
+app.listen(port, () => console.log(`Example app listening on port ${port}!`));


### PR DESCRIPTION
This is pretty much a copy of the same functionality for the Drupal chart. Unfortunately due to limitations of how variables can be passed into helm templates, we cannot have a template that takes in both the service definition and the global mount definitions, so there is some duplication.

As proof that this is working, https://feature-slt-389.frontend-project-k8s.silta.wdr.io/world/files/lastupdate.txt has the timestamp of the last cronjob.