### PR TITLE
SLT-391: Add elasticsearch support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,15 @@ workflows:
                 dockerfile: 'silta/world.Dockerfile'
                 path: '.'
                 identifier: 'world'
+            - run:
+                name: Add elastic repo for elasticsearch
+                command: helm repo add elastic https://helm.elastic.co
+            - run:
+                name: Build local helm dependencies
+                command: helm dependency build ./chart
+            - run:
+                name: Dry-run helm install
+                command: helm install --dry-run ./chart
           context: 'global_nonprod'
           filters:
             branches:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 
 node_modules/
-
+chart/charts
 
 

--- a/chart/requirements.lock
+++ b/chart/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: elasticsearch
+  repository: https://helm.elastic.co
+  version: 7.4.1
+digest: sha256:cd78bac322cff29e1c507389a1f6782ed9ccaa075a292d06e4e3db8aa80d2a9f
+generated: "2019-11-12T16:44:31.678297+01:00"

--- a/chart/requirements.yaml
+++ b/chart/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+- name: elasticsearch
+  version: 7.4.x
+  repository: https://helm.elastic.co
+  condition: elasticsearch.enabled

--- a/chart/templates/_overrides.tpl
+++ b/chart/templates/_overrides.tpl
@@ -1,0 +1,19 @@
+{{/*
+Override templates from subcharts.
+*/}}
+
+{{/*
+The elasticsearch chart uses an incompatible naming scheme,
+we make it compatible by overriding the following templates.
+*/}}
+{{- define "uname" -}}
+{{ .Release.Name }}-es
+{{- end }}
+
+{{- define "masterService" -}}
+{{ .Release.Name }}-es
+{{- end }}
+
+{{- define "endpoints" -}}
+{{ .Release.Name }}-es-0
+{{- end -}}

--- a/chart/templates/services-cron.yaml
+++ b/chart/templates/services-cron.yaml
@@ -36,6 +36,10 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
+            {{- if .Values.elasticsearch.enabled }}
+            - name: ELASTICSEARCH_HOST
+              value: {{ .Release.Name }}-es
+            {{- end }}
             command: ["/bin/sh", "-c"]
             args:
               - |

--- a/chart/templates/services-cron.yaml
+++ b/chart/templates/services-cron.yaml
@@ -36,9 +36,9 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
-            {{- if .Values.elasticsearch.enabled }}
+            {{- if $.Values.elasticsearch.enabled }}
             - name: ELASTICSEARCH_HOST
-              value: {{ .Release.Name }}-es
+              value: {{ $.Release.Name }}-es
             {{- end }}
             command: ["/bin/sh", "-c"]
             args:

--- a/chart/templates/services-deployment.yaml
+++ b/chart/templates/services-deployment.yaml
@@ -50,6 +50,10 @@ spec:
         - name: "{{ $index }}_HOST"
           value: "{{ $.Release.Name }}-{{ $index }}:{{ default $.Values.serviceDefaults.port $service.port }}"
         {{- end }}
+        {{- if .Values.elasticsearch.enabled }}
+        - name: ELASTICSEARCH_HOST
+          value: {{ .Release.Name }}-es
+        {{- end }}
         resources:
           {{ if $service.resources -}}
           {{ merge $service.resources $.Values.serviceDefaults.resources | toYaml | nindent 10 }}

--- a/chart/templates/services-deployment.yaml
+++ b/chart/templates/services-deployment.yaml
@@ -50,9 +50,9 @@ spec:
         - name: "{{ $index }}_HOST"
           value: "{{ $.Release.Name }}-{{ $index }}:{{ default $.Values.serviceDefaults.port $service.port }}"
         {{- end }}
-        {{- if .Values.elasticsearch.enabled }}
+        {{- if $.Values.elasticsearch.enabled }}
         - name: ELASTICSEARCH_HOST
-          value: {{ .Release.Name }}-es
+          value: {{ $.Release.Name }}-es
         {{- end }}
         resources:
           {{ if $service.resources -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -159,3 +159,38 @@ serviceDefaults:
     limits:
       cpu: 1000m
       memory: 256Mi
+
+elasticsearch:
+  enabled: false
+
+  # The elasticsearch version to use.
+  # It's a good idea to tag this in your silta.yml
+  imageTag: 7.4.1
+
+  replicas: 1
+  minimumMasterNodes: 1
+  clusterHealthCheckParams: 'wait_for_status=yellow&timeout=1s'
+
+  # This value should be slightly less than 50% of the requested memory.
+  esJavaOpts: -Xmx220m -Xms220m
+  xpack:
+    enabled: false
+  volumeClaimTemplate:
+    resources.requests.storage: 1Gi
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      preference:
+        matchExpressions:
+        - key: cloud.google.com/gke-nodepool
+          operator: NotIn
+          values:
+          - static-ip

--- a/hello/package-lock.json
+++ b/hello/package-lock.json
@@ -4,6 +4,34 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@elastic/elasticsearch": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.4.0.tgz",
+      "integrity": "sha512-HpEKHH6mHQRvea3lw4NNJw9ZUS1KmkpwWKHucaHi1svDn+/fEAwY0wD8egL1vZJo4ZmWfCQMjVqGL+Hoy1HYRw==",
+      "requires": {
+        "debug": "^4.1.1",
+        "decompress-response": "^4.2.0",
+        "into-stream": "^5.1.0",
+        "ms": "^2.1.1",
+        "once": "^1.4.0",
+        "pump": "^3.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -63,12 +91,25 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
+      }
+    },
+    "decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "requires": {
+        "mimic-response": "^2.0.0"
       }
     },
     "depd": {
@@ -90,6 +131,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -162,6 +211,15 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
     "http-errors": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
@@ -187,10 +245,24 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "into-stream": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-5.1.1.tgz",
+      "integrity": "sha512-krrAJ7McQxGGmvaYbB7Q1mcA+cRwg9Ij2RfWIeVesNBgVDZmzY/Fa4IpZUT3bmdRzMzdf/mzltCG2Dq99IZGBA==",
+      "requires": {
+        "from2": "^2.3.0",
+        "p-is-promise": "^3.0.0"
+      }
+    },
     "ipaddr.js": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -225,6 +297,11 @@
         "mime-db": "1.40.0"
       }
     },
+    "mimic-response": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.0.0.tgz",
+      "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ=="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -243,6 +320,19 @@
         "ee-first": "1.1.1"
       }
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "p-is-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+      "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ=="
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -253,6 +343,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "proxy-addr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
@@ -260,6 +355,15 @@
       "requires": {
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.0"
+      }
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "qs": {
@@ -281,6 +385,20 @@
         "http-errors": "1.7.2",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "safe-buffer": {
@@ -341,6 +459,14 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -360,6 +486,11 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -369,6 +500,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     }
   }
 }

--- a/hello/package.json
+++ b/hello/package.json
@@ -5,14 +5,15 @@
   "author": "Janis Bebritis <janis.bebritis@wunder.io>",
   "license": "UNLICENSED",
   "repository": {
-    "type" : "git",
-    "url" : "git@github.com:wunderio/frontend-project-k8s.git"
+    "type": "git",
+    "url": "git@github.com:wunderio/frontend-project-k8s.git"
   },
   "main": "server.js",
   "scripts": {
     "server": "node server.js"
   },
   "dependencies": {
+    "@elastic/elasticsearch": "^7.4.0",
     "express": "^4.17.1"
   }
 }

--- a/hello/server.js
+++ b/hello/server.js
@@ -2,7 +2,7 @@ const express = require('express')
 const app = express()
 const port = parseInt(process.env.PORT, 10) || 3000;
 const { Client } = require('@elastic/elasticsearch')
-const client = new Client({ node: `${process.env.ELASTICSEARCH_HOST}:9200` })
+const client = new Client({ node: `http://${process.env.ELASTICSEARCH_HOST}:9200` })
 
 
 app.get('/hello', (req, res) => res.send('Hello'));

--- a/hello/server.js
+++ b/hello/server.js
@@ -2,7 +2,7 @@ const express = require('express')
 const app = express()
 const port = parseInt(process.env.PORT, 10) || 3000;
 const { Client } = require('@elastic/elasticsearch')
-const client = new Client({ node: `${process.env}:9200` })
+const client = new Client({ node: `${process.env.ELASTICSEARCH_HOST}:9200` })
 
 
 app.get('/hello', (req, res) => res.send('Hello'));

--- a/hello/server.js
+++ b/hello/server.js
@@ -1,7 +1,15 @@
 const express = require('express')
 const app = express()
 const port = parseInt(process.env.PORT, 10) || 3000;
+const { Client } = require('@elastic/elasticsearch')
+const client = new Client({ node: `${process.env}:9200` })
 
-app.get('/hello', (req, res) => res.send('Hello'))
 
-app.listen(port, () => console.log(`Example app listening on port ${port}!`))
+app.get('/hello', (req, res) => res.send('Hello'));
+
+app.get('/hello/elasticsearch-status', async (req, res) => {
+  const health = await client.cluster.health();
+  res.send(health.status);
+});
+
+app.listen(port, () => console.log(`Example app listening on port ${port}!`));

--- a/hello/server.js
+++ b/hello/server.js
@@ -10,7 +10,7 @@ app.get('/hello', (req, res) => res.send('Hello'));
 app.get('/hello/elasticsearch-status', async (req, res) => {
   const health = await client.cluster.health();
   console.log(health);
-  res.send(health.status);
+  res.send(health.body.status);
 });
 
 app.listen(port, () => console.log(`Example app listening on port ${port}!`));

--- a/hello/server.js
+++ b/hello/server.js
@@ -9,6 +9,7 @@ app.get('/hello', (req, res) => res.send('Hello'));
 
 app.get('/hello/elasticsearch-status', async (req, res) => {
   const health = await client.cluster.health();
+  console.log(health);
   res.send(health.status);
 });
 

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -31,3 +31,6 @@ mounts:
     mountPath: /app/files
     storageClassName: silta-shared
     csiDriverName: csi-rclone
+
+elasticsearch:
+  enabled: true


### PR DESCRIPTION
Here too some duplication with the Drupal chart, but I think that's difficult to avoid.

As an example, https://feature-slt-391.frontend-project-k8s.silta.wdr.io/hello/elasticsearch-status should return the cluster health.