### PR TITLE
SLT-400: Add SSH support to the frontend chart

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,18 +1,15 @@
 Deployed {{ .Release.Name }} successfully, your site is available here:
 
-  {{- range $index, $service := .Values.services }}
+{{- range $index, $service := .Values.services }}
+
   {{- if default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}
   http://{{- template "frontend.domain" $ }}{{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}
-  {{- end }}
-  {{- end }}
 
   {{- range $index, $domain := .Values.exposeDomains }}
-  {{- range $index, $service := $.Values.services }}
-  {{- if default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}
   http://{{ $domain.hostname }}{{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}
   {{- end }}
   {{- end }}
-  {{- end }}
+{{- end }}
 
 {{ if .Values.nginx.basicauth.enabled -}}
 Basicauth username: {{ .Values.nginx.basicauth.credentials.username }}

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -5,7 +5,7 @@ Deployed {{ .Release.Name }} successfully, your site is available here:
   {{- if default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}
   http://{{- template "frontend.domain" $ }}{{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}
 
-  {{- range $index, $domain := .Values.exposeDomains }}
+  {{- range $index, $domain := $.Values.exposeDomains }}
   http://{{ $domain.hostname }}{{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}
   {{- end }}
   {{- end }}

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,24 +1,20 @@
 Deployed {{ .Release.Name }} successfully, your site is available here:
-
-{{- range $index, $service := .Values.services }}
-
-  {{- if default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}
+{{ range $index, $service := .Values.services -}}
+  {{ if default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}
   http://{{- template "frontend.domain" $ }}{{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}
-
   {{- range $index, $domain := $.Values.exposeDomains }}
   http://{{ $domain.hostname }}{{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}
-  {{- end }}
-  {{- end }}
-
-{{ if $.Values.shell.enabled }}
-  SSH connection (limited access through VPN):
-
-    ssh www-admin@{{ template "frontend.environment.hostname" $ }}-shell-{{ $index }}.{{ $.Release.Namespace }} -J {{ include "frontend.jumphost" $ }}
-
-{{- end }}
+  {{- end -}}
+  {{- end -}}
 {{- end }}
 
 {{ if .Values.nginx.basicauth.enabled -}}
 Basicauth username: {{ .Values.nginx.basicauth.credentials.username }}
 Basicauth password: {{ .Values.nginx.basicauth.credentials.password }}
 {{- end }}
+{{ if $.Values.shell.enabled }}
+SSH connection (limited access through VPN):
+{{ range $index, $service := .Values.services }}
+    ssh www-admin@{{ template "frontend.environment.hostname" $ }}-shell-{{ $index }}.{{ $.Release.Namespace }} -J {{ include "frontend.jumphost" $ }}
+{{- end }}
+{{- end -}}

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -9,6 +9,13 @@ Deployed {{ .Release.Name }} successfully, your site is available here:
   http://{{ $domain.hostname }}{{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}
   {{- end }}
   {{- end }}
+
+{{ if $.Values.shell.enabled }}
+  SSH connection (limited access through VPN):
+
+    ssh www-admin@{{ template "frontend.environment.hostname" $ }}-shell-{{ $index }}.{{ $.Release.Namespace }} -J {{ include "frontend.jumphost" $ }}
+
+{{- end }}
 {{- end }}
 
 {{ if .Values.nginx.basicauth.enabled -}}

--- a/chart/templates/_domains.tpl
+++ b/chart/templates/_domains.tpl
@@ -1,0 +1,31 @@
+
+
+{{- define "frontend.domain" -}}
+{{- $projectName := regexReplaceAll "[^[:alnum:]]" (.Values.projectName | default .Release.Namespace) "-"  | trimSuffix "-" | lower }}
+{{- $projectNameHash := sha256sum $projectName | trunc 3 }}
+{{- $projectName := (ge (len $projectName) 30) | ternary (print ($projectName | trunc 27) $projectNameHash ) $projectName}}
+
+{{- $environmentName := regexReplaceAll "[^[:alnum:]]" (.Values.environmentName | default .Release.Name) "-" | trimSuffix "-" | lower }}
+{{- $environmentNameHash := sha256sum $environmentName | trunc 3 }}
+{{- $maxEnvironmentNameLength := int (sub 62 (add (len .Values.clusterDomain) (len $projectName))) }}
+{{- $environmentName := (ge (len $environmentName) $maxEnvironmentNameLength) | ternary (print ($environmentName | trunc (int (sub $maxEnvironmentNameLength 3))) $environmentNameHash) $environmentName -}}
+
+{{ $environmentName }}.{{ $projectName }}.{{ .Values.clusterDomain }}
+{{- end -}}
+
+{{- define "frontend.referenceEnvironment" -}}
+{{ regexReplaceAll "[^[:alnum:]]" .Values.referenceData.referenceEnvironment "-" | lower | trunc 50 | trimSuffix "-" }}
+{{- end -}}
+
+{{- define "frontend.environment.hostname" -}}
+{{ regexReplaceAll "[^[:alnum:]]" (.Values.environmentName | default .Release.Name) "-" | lower | trunc 50 | trimSuffix "-" }}
+{{- end -}}
+
+# SSH-related hosts
+{{- define "frontend.jumphost" -}}
+www-admin@ssh.{{ .Values.clusterDomain }}
+{{- end -}}
+
+{{- define "frontend.shellHost" -}}
+www-admin@{{ template "frontend.environment.hostname" . }}-shell.{{ .Release.Namespace }}
+{{- end -}}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -3,24 +3,6 @@ app: {{ .Values.app | quote }}
 release: {{ .Release.Name }}
 {{- end }}
 
-{{- define "frontend.domain" -}}
-{{- $projectName := regexReplaceAll "[^[:alnum:]]" (.Values.projectName | default .Release.Namespace) "-"  | trimSuffix "-" | lower }}
-{{- $projectNameHash := sha256sum $projectName | trunc 3 }}
-{{- $projectName := (ge (len $projectName) 30) | ternary (print ($projectName | trunc 27) $projectNameHash ) $projectName}}
-
-{{- $environmentName := regexReplaceAll "[^[:alnum:]]" (.Values.environmentName | default .Release.Name) "-" | trimSuffix "-" | lower }}
-{{- $environmentNameHash := sha256sum $environmentName | trunc 3 }}
-{{- $maxEnvironmentNameLength := int (sub 62 (add (len .Values.clusterDomain) (len $projectName))) }}
-{{- $environmentName := (ge (len $environmentName) $maxEnvironmentNameLength) | ternary (print ($environmentName | trunc (int (sub $maxEnvironmentNameLength 3))) $environmentNameHash) $environmentName -}}
-
-{{ $environmentName }}.{{ $projectName }}.{{ .Values.clusterDomain }}
-{{- end -}} 
-
-{{- define "frontend.referenceEnvironment" -}}
-{{ regexReplaceAll "[^[:alnum:]]" .Values.referenceData.referenceEnvironment "-" | lower }}
-{{- end -}}
-
-
 {{- define "frontend.basicauth" }}
   {{- if .Values.nginx.basicauth.enabled }}
   satisfy any;

--- a/chart/templates/services-deployment.yaml
+++ b/chart/templates/services-deployment.yaml
@@ -84,7 +84,7 @@ spec:
         {{ if $.Values.shell.enabled -}}
         - name: shell-keys
           persistentVolumeClaim:
-            claimName: {{ $.Release.Name }}-shell-keys-{{ $index }}
+            claimName: {{ $.Release.Name }}-shell-keys
         {{- end }}
 
 {{- if $service.autoscaling }}

--- a/chart/templates/services-deployment.yaml
+++ b/chart/templates/services-deployment.yaml
@@ -54,10 +54,12 @@ spec:
         - name: ELASTICSEARCH_HOST
           value: {{ $.Release.Name }}-es
         {{- end }}
+        {{ if $.Values.shell.enabled -}}
         - name: GITAUTH_API_TOKEN
           value: "{{ $.Values.shell.gitAuth.apiToken }}"
         - name: GITAUTH_REPOSITORY_URL
           value: "{{ $.Values.shell.gitAuth.repositoryUrl }}"
+        {{- end }}
         resources:
           {{ if $service.resources -}}
           {{ merge $service.resources $.Values.serviceDefaults.resources | toYaml | nindent 10 }}

--- a/chart/templates/services-deployment.yaml
+++ b/chart/templates/services-deployment.yaml
@@ -54,6 +54,10 @@ spec:
         - name: ELASTICSEARCH_HOST
           value: {{ $.Release.Name }}-es
         {{- end }}
+        - name: GITAUTH_API_TOKEN
+          value: "{{ .Values.shell.gitAuth.apiToken }}"
+        - name: GITAUTH_REPOSITORY_URL
+          value: "{{ .Values.shell.gitAuth.repositoryUrl }}"
         resources:
           {{ if $service.resources -}}
           {{ merge $service.resources $.Values.serviceDefaults.resources | toYaml | nindent 10 }}

--- a/chart/templates/services-deployment.yaml
+++ b/chart/templates/services-deployment.yaml
@@ -55,9 +55,9 @@ spec:
           value: {{ $.Release.Name }}-es
         {{- end }}
         - name: GITAUTH_API_TOKEN
-          value: "{{ .Values.shell.gitAuth.apiToken }}"
+          value: "{{ $.Values.shell.gitAuth.apiToken }}"
         - name: GITAUTH_REPOSITORY_URL
-          value: "{{ .Values.shell.gitAuth.repositoryUrl }}"
+          value: "{{ $.Values.shell.gitAuth.repositoryUrl }}"
         resources:
           {{ if $service.resources -}}
           {{ merge $service.resources $.Values.serviceDefaults.resources | toYaml | nindent 10 }}

--- a/chart/templates/services-deployment.yaml
+++ b/chart/templates/services-deployment.yaml
@@ -121,5 +121,6 @@ spec:
   resources:
     requests:
       storage: 50M
+---
 {{- end }}
 {{- end }}

--- a/chart/templates/services-deployment.yaml
+++ b/chart/templates/services-deployment.yaml
@@ -33,6 +33,10 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
+          {{ if $.Values.shell.enabled -}}
+          - name: shell-keys
+            mountPath: /etc/ssh/keys
+          {{- end }}
         livenessProbe:
           tcpSocket:
             port: {{ default $.Values.serviceDefaults.port $service.port }}
@@ -77,6 +81,11 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{ if $.Values.shell.enabled -}}
+        - name: shell-keys
+          persistentVolumeClaim:
+            claimName: {{ $.Release.Name }}-shell-keys
+        {{- end }}
 
 {{- if $service.autoscaling }}
 {{- if $service.autoscaling.enabled }}
@@ -99,4 +108,18 @@ spec:
 {{- end }}
 {{- end }}
 ---
+{{- if $.Values.shell.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $.Release.Name }}-shell-keys
+  labels:
+    {{ include "frontend.release_labels" $ | indent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50M
+{{- end }}
 {{- end }}

--- a/chart/templates/services-deployment.yaml
+++ b/chart/templates/services-deployment.yaml
@@ -84,7 +84,7 @@ spec:
         {{ if $.Values.shell.enabled -}}
         - name: shell-keys
           persistentVolumeClaim:
-            claimName: {{ $.Release.Name }}-shell-keys
+            claimName: {{ $.Release.Name }}-shell-keys-{{ $index }}
         {{- end }}
 
 {{- if $service.autoscaling }}
@@ -112,7 +112,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ $.Release.Name }}-shell-keys
+  name: {{ $.Release.Name }}-shell-keys-{{ $index }}
   labels:
     {{ include "frontend.release_labels" $ | indent 4 }}
 spec:

--- a/chart/templates/services-deployment.yaml
+++ b/chart/templates/services-deployment.yaml
@@ -108,19 +108,4 @@ spec:
 {{- end }}
 {{- end }}
 ---
-{{- if $.Values.shell.enabled }}
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ $.Release.Name }}-shell-keys-{{ $index }}
-  labels:
-    {{ include "frontend.release_labels" $ | indent 4 }}
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 50M
----
-{{- end }}
 {{- end }}

--- a/chart/templates/services-service.yaml
+++ b/chart/templates/services-service.yaml
@@ -14,6 +14,7 @@ spec:
     {{ include "frontend.release_labels" $ | indent 4 }}
     deployment: frontend-{{ $index }}
 ---
+{{ if $.Values.shell.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -29,4 +30,5 @@ spec:
     {{ include "frontend.release_labels" $ | indent 4 }}
     deployment: frontend-{{ $index }}
 ---
+{{- end }}
 {{- end }}

--- a/chart/templates/services-service.yaml
+++ b/chart/templates/services-service.yaml
@@ -18,7 +18,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $.Release.Name }}-{{ $index }}-shell
+  name: {{ template "frontend.environment.hostname" $ }}-shell-{{ $index }}
   labels:
     {{ include "frontend.release_labels" $ | indent 4 }}
 spec:

--- a/chart/templates/services-service.yaml
+++ b/chart/templates/services-service.yaml
@@ -14,4 +14,19 @@ spec:
     {{ include "frontend.release_labels" $ | indent 4 }}
     deployment: frontend-{{ $index }}
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $.Release.Name }}-{{ $index }}-shell
+  labels:
+    {{ include "frontend.release_labels" $ | indent 4 }}
+spec:
+  type: NodePort
+  externalTrafficPolicy: Local
+  ports:
+    - port: 22
+  selector:
+    {{ include "frontend.release_labels" $ | indent 4 }}
+    deployment: frontend-{{ $index }}
+---
 {{- end }}

--- a/chart/templates/volumes.yaml
+++ b/chart/templates/volumes.yaml
@@ -65,6 +65,7 @@ spec:
     volumeHandle: {{ $.Release.Name }}-shell-keys
     volumeAttributes:
       remotePathSuffix: /{{ $.Release.Namespace }}/{{ $.Values.environmentName }}/shell-keys
+      umask: "077"
   {{- end }}
 {{- end }}
 ---

--- a/chart/templates/volumes.yaml
+++ b/chart/templates/volumes.yaml
@@ -44,3 +44,41 @@ spec:
 ---
 {{- end -}}
 {{- end }}
+
+{{- if $.Values.shell.enabled }}
+{{- if eq $.Values.shell.mount.storageClassName "silta-shared" }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ $.Release.Name }}-shell-keys
+  labels:
+    name: {{ $.Release.Name }}-shell-keys
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: 50M
+  storageClassName: "silta-shared"
+  {{- if $.Values.shell.mount.csiDriverName }}
+  csi:
+    driver: {{ $.Values.shell.mount.csiDriverName }}
+    volumeHandle: {{ $.Release.Name }}-shell-keys
+    volumeAttributes:
+      remotePathSuffix: /{{ $.Release.Namespace }}/{{ $.Values.environmentName }}/shell-keys
+  {{- end }}
+{{- end }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $.Release.Name }}-shell-keys
+  labels:
+    {{ include "frontend.release_labels" $ | indent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50M
+---
+{{- end }}

--- a/chart/templates/volumes.yaml
+++ b/chart/templates/volumes.yaml
@@ -76,7 +76,7 @@ metadata:
     {{ include "frontend.release_labels" $ | indent 4 }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: 50M

--- a/chart/templates/volumes.yaml
+++ b/chart/templates/volumes.yaml
@@ -58,7 +58,7 @@ spec:
     - ReadWriteMany
   capacity:
     storage: 50M
-  storageClassName: "silta-shared"
+  storageClassName: {{ $.Values.shell.mount.storageClassName }}
   {{- if $.Values.shell.mount.csiDriverName }}
   csi:
     driver: {{ $.Values.shell.mount.csiDriverName }}
@@ -75,6 +75,7 @@ metadata:
   labels:
     {{ include "frontend.release_labels" $ | indent 4 }}
 spec:
+  storageClassName: {{ $.Values.shell.mount.storageClassName }}
   accessModes:
     - ReadWriteMany
   resources:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -146,6 +146,13 @@ mounts:
 #    storageClassName: silta-shared
 #    csiDriverName: csi-rclone
 
+# Provide SSH access based on GitHub public keys and repository access.
+shell:
+  enabled: false
+  gitAuth:
+    apiToken: ''
+    repositoryURL: ''
+
 # Provide defaults for all services.
 # Note that only keys used here can be overridden.
 serviceDefaults:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -152,6 +152,9 @@ shell:
   gitAuth:
     apiToken: ''
     repositoryURL: ''
+  mount:
+    storageClassName: silta-shared
+    csiDriverName: csi-rclone
 
 # Provide defaults for all services.
 # Note that only keys used here can be overridden.

--- a/silta/hello.Dockerfile
+++ b/silta/hello.Dockerfile
@@ -1,6 +1,3 @@
-FROM node:12.8-alpine
+FROM wunderio/silta-node
 
 COPY ./hello /app
-WORKDIR /app
-
-CMD npm run start

--- a/silta/hello.Dockerfile
+++ b/silta/hello.Dockerfile
@@ -1,3 +1,3 @@
-FROM wunderio/silta-node
+FROM wunderio/silta-node:latest
 
 COPY ./hello /app

--- a/silta/hello.Dockerfile
+++ b/silta/hello.Dockerfile
@@ -1,3 +1,5 @@
 FROM wunderio/silta-node:latest
 
 COPY ./hello /app
+
+CMD npm run start

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -34,3 +34,6 @@ mounts:
 
 elasticsearch:
   enabled: true
+
+shell:
+  enabled: true

--- a/silta/world.Dockerfile
+++ b/silta/world.Dockerfile
@@ -1,6 +1,5 @@
-FROM node:12.8-alpine
+FROM wunderio/silta-node:latest
 
 COPY ./world /app
-WORKDIR /app
 
 CMD npm run start


### PR DESCRIPTION
This is now working, so I'm sharing it for review already. I believe all the changes to the chart itself are ready, some more changes that go along in the base docker image:

- Update the entrypoint script so that ssh host keys are only generated if they are not present yet. 
- Update the entrypoint so that sshd is only started if the environment variables are present.
- Tag a release for the `silta-node` image. We want to use a tagged release as the base image for projects.