### PR TITLE
Add test and fix for missing environment variables.

### DIFF
--- a/chart/templates/services-cron.yaml
+++ b/chart/templates/services-cron.yaml
@@ -38,9 +38,23 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
+            - name: 'PORT'
+              value: {{ default $.Values.serviceDefaults.port $service.port | quote }}
+            - name: 'ENVIRONMENT_DOMAIN'
+              value: {{ template "frontend.domain" $ }}
+            - name: 'RELEASE_NAME'
+              value: {{ $.Release.Name | quote }}
+            {{- range $index, $service := $.Values.services }}
+            - name: "{{ $index }}_HOST"
+              value: "{{ $.Release.Name }}-{{ $index }}:{{ default $.Values.serviceDefaults.port $service.port }}"
+            {{- end }}
             {{- if $.Values.elasticsearch.enabled }}
             - name: ELASTICSEARCH_HOST
               value: {{ $.Release.Name }}-es
+            {{- end }}
+            {{- if $.Values.rabbitmq.enabled }}
+            - name: RABBITMQ_HOST
+              value: {{ $.Release.Name }}-rabbitmq
             {{- end }}
             command: ["/bin/sh", "-c"]
             args:

--- a/chart/tests/rabbitmq_test.yaml
+++ b/chart/tests/rabbitmq_test.yaml
@@ -1,0 +1,26 @@
+suite: RabbitMQ
+templates:
+  - services-deployment.yaml
+  - services-cron.yaml
+tests:
+  - it: gets exposed when enabled
+    set:
+      services.foo:
+        image: 'bar'
+        cron:
+          foo:
+            command: echo "Hello world"
+            schedule: '1 2 3 * *'
+      rabbitmq.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RABBITMQ_HOST
+            value: RELEASE-NAME-rabbitmq
+      - template: services-cron.yaml
+        contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: RABBITMQ_HOST
+            value: RELEASE-NAME-rabbitmq


### PR DESCRIPTION
I'd like to reduce the duplication, but with the current limitations of helm template it's not possible to have call a helper function with a non-global scope (the current `$service`) and still have access to global values (in our case the default values).