### PR TITLE
Create release info configmap, add branch name to it

### DIFF
--- a/chart/templates/release-info.yaml
+++ b/chart/templates/release-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-release
+  labels:
+    {{- include "frontend.release_labels" . | indent 4 }}
+    branchName: {{ regexReplaceAll "[^[:alnum:]]" .Values.branchName "-" | quote }}
+data: 
+  branchName: {{ .Values.branchName | quote }}

--- a/chart/templates/release-info.yaml
+++ b/chart/templates/release-info.yaml
@@ -4,6 +4,5 @@ metadata:
   name: {{ .Release.Name }}-release
   labels:
     {{- include "frontend.release_labels" . | indent 4 }}
-    branchName: {{ regexReplaceAll "[^[:alnum:]]" .Values.branchName "-" | quote }}
 data: 
   branchName: {{ .Values.branchName | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -11,6 +11,9 @@ projectName: ""
 # This name is mainly used to create nice subdomains for each environment.
 environmentName: ""
 
+# Repository branch name. This will be filled automatically by CI.
+branchName: ""
+
 # The app label added to our Kubernetes resources.
 app: frontend
 


### PR DESCRIPTION
### DO NOT MERGE, SOME OF THIS WILL BE ADDED TO LIBRARY SUBCHART
Adds configmap with a `branchName` label that stores branch name. This will be needed for release remover.
See this PR: https://github.com/wunderio/silta-deployment-remover/pull/12