### PR TITLE
SLT-474: Replacing stable repo with bitnami

### DIFF
--- a/charts/frontend/Chart.lock
+++ b/charts/frontend/Chart.lock
@@ -3,10 +3,10 @@ dependencies:
   repository: https://helm.elastic.co
   version: 7.4.1
 - name: rabbitmq
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.bitnami.com/bitnami
   version: 6.17.5
 - name: silta-release
   repository: file://../silta-release
   version: 0.1.1
-digest: sha256:af56513c0a081e79457b8aa77d1cccc225b407b713479bb7ab98013caf538178
-generated: "2020-04-07T13:50:07.997276+02:00"
+digest: sha256:dd58db136bbeb96a9bf3e4f657fbae4280fffed7c618f7d8220a47f1d6e313d3
+generated: "2020-05-06T13:31:48.717227326Z"

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
   condition: elasticsearch.enabled
 - name: rabbitmq
   version: 6.17.x
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.bitnami.com/bitnami
   condition: rabbitmq.enabled
 - name: silta-release
   version: 0.1.1


### PR DESCRIPTION
Rabbitmq chart repository changed to bitnami