### PR TITLE
Allow service deployment strategy override

### DIFF
--- a/charts/frontend/templates/services-deployment.yaml
+++ b/charts/frontend/templates/services-deployment.yaml
@@ -7,6 +7,8 @@ metadata:
     {{ include "frontend.release_labels" $ | indent 4 }}
 spec:
   replicas: {{ default 1 $service.replicas }}
+  strategy:
+    {{ default $.Values.serviceDefaults.strategy $service.strategy | toYaml }}
   selector:
     matchLabels:
       {{ include "frontend.release_labels" $ | indent 6 }}

--- a/charts/frontend/tests/services-deployment_test.yaml
+++ b/charts/frontend/tests/services-deployment_test.yaml
@@ -249,3 +249,27 @@ tests:
             resource:
               name: cpu
               targetAverageUtilization: 100
+
+  - it: uses RollingUpdate as default service deployment strategy
+    set:
+      services:
+        foo:
+          exposedRoute: '/bar'
+          image: 'bar'
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+
+  - it: allows service deployment strategy override
+    set:
+      services:
+        foo:
+          image: 'bar'
+          exposedRoute: '/bar'
+          strategy:
+            foo: BAR
+    asserts:
+      - equal:
+          path: spec.strategy.foo
+          value: BAR

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -190,6 +190,9 @@ serviceDefaults:
       memory: 64Mi
     limits:
       memory: 256Mi
+  # https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  strategy:
+    type: RollingUpdate
   autoscaling:
     enabled: false
     minReplicas: 1


### PR DESCRIPTION
This option is required for workloads using RWO storage accessmode. Rolling update does not kill the container that is currently using storage and so the mount can not be made to the new one.

Related commit: https://github.com/wunderio/charts/commit/1b32c3d92a76ef83ba42bbd33cac11ecc2441dd6