### PR TITLE
Feature/proxy

### DIFF
--- a/charts/frontend/templates/_helpers.tpl
+++ b/charts/frontend/templates/_helpers.tpl
@@ -24,3 +24,24 @@ release: {{ .Release.Name }}
   value: {{ $label }}
 {{- end }}
 {{- end }}
+
+{{- define "services.env" }}
+{{ $proxy := ( index .Values "silta-release" ).proxy }}
+{{ if $proxy.enabled }}
+# The http_proxy needs to be defined in lowercase.
+# The HTTPS_PROXY needs to be defined in uppercase.
+# It is recommended to define both in both cases.
+- name: http_proxy
+  value: "{{ $proxy.url }}:{{ $proxy.port }}"
+- name: HTTP_PROXY
+  value: "{{ $proxy.url }}:{{ $proxy.port }}"
+- name: https_proxy
+  value: "{{ $proxy.url }}:{{ $proxy.port }}"
+- name: HTTPS_PROXY
+  value: "{{ $proxy.url }}:{{ $proxy.port }}"
+- name: no_proxy
+  value: .svc.cluster.local,{{ .Release.Name }}-es{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
+- name: NO_PROXY
+  value: .svc.cluster.local,{{ .Release.Name }}-es{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
+{{- end }}
+{{- end }}

--- a/charts/frontend/templates/services-cron.yaml
+++ b/charts/frontend/templates/services-cron.yaml
@@ -84,6 +84,21 @@ spec:
             {{- end }}
             {{- end }}
           restartPolicy: OnFailure
+
+          {{ if or $job.nodeSelector $service.nodeSelector -}}
+          nodeSelector:
+            {{ if $job.nodeSelector }}
+            {{- $job.nodeSelector | toYaml | nindent 12 }}
+            {{ else }}
+            {{- $service.nodeSelector | toYaml | nindent 12 }}
+            {{- end }}
+          tolerations:
+            {{ if $job.nodeSelector }}
+            {{- include "frontend.tolerations" $job.nodeSelector | nindent 12 }}
+            {{ else }}
+            {{- include "frontend.tolerations" $service.nodeSelector | nindent 12 }}
+            {{- end }}
+          {{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/frontend/templates/services-cron.yaml
+++ b/charts/frontend/templates/services-cron.yaml
@@ -36,6 +36,7 @@ spec:
               {{- end }}
               {{- end }}
             env:
+            {{- include "services.env" $ | nindent 12 }}
             {{- range $key, $val := $service.env }}
             - name: {{ $key }}
               value: {{ $val | quote }}

--- a/charts/frontend/templates/services-deployment.yaml
+++ b/charts/frontend/templates/services-deployment.yaml
@@ -50,6 +50,7 @@ spec:
           tcpSocket:
             port: {{ default $.Values.serviceDefaults.port $service.port }}
         env:
+        {{- include "services.env" $ | indent 8 }}
         {{- range $key, $val := $service.env }}
         - name: {{ $key }}
           value: {{ $val | quote }}

--- a/charts/frontend/values.schema.json
+++ b/charts/frontend/values.schema.json
@@ -17,6 +17,12 @@
     "serviceDefaults": { "type": "object" },
     "shell": { "type": "object" },
     "mounts": { "type": "object" },
+    "mariadb": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
     "elasticsearch": {
       "type": "object",
       "properties": {

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -1,4 +1,5 @@
 # Configuration for the wunderio/silta-release subchart.
+# see: https://github.com/wunderio/charts/blob/master/silta-release/values.yaml
 silta-release:
   downscaler:
     enabled: true

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -143,11 +143,13 @@ services: {}
   #     limits:
   #       memory: 512Mi
 
-  #   cron:
-  #     example:
-  #       command: echo "hello world"
-  #       schedule: "~ 1 * * *"
-  #       parallelism: 1
+    # cron:
+    #   example:
+    #     command: echo "hello world"
+    #     schedule: "~ 1 * * *"
+    #     parallelism: 1
+    #     nodeSelector:
+    #       cloud.google.com/gke-nodepool: static-ip
 
   #   nodeSelector:
   #     cloud.google.com/gke-nodepool: static-ip

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -48,3 +48,7 @@ rabbitmq:
 
 shell:
   enabled: true
+
+silta-release:
+  proxy:
+    enabled: true


### PR DESCRIPTION
- nodeSelector for frontend cronjobs
- silta-release.proxy for frontend service deployments and cronjobs
- Allows mariadb credentials in values file (mariadb feature is WIP, this is needed)