### PR TITLE
Feature/mariadb

### DIFF
--- a/charts/frontend/Chart.lock
+++ b/charts/frontend/Chart.lock
@@ -1,4 +1,7 @@
 dependencies:
+- name: mariadb
+  repository: https://charts.bitnami.com/bitnami
+  version: 7.10.0
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.4.1
@@ -8,5 +11,5 @@ dependencies:
 - name: silta-release
   repository: file://../silta-release
   version: 0.1.1
-digest: sha256:dd58db136bbeb96a9bf3e4f657fbae4280fffed7c618f7d8220a47f1d6e313d3
-generated: "2020-05-06T13:31:48.717227326Z"
+digest: sha256:1745fd0ac7b81e6399e842b49794b78124fec84377daa2ef743d756adea1709d
+generated: "2020-09-16T12:43:16.656135136+03:00"

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -3,6 +3,10 @@ name: frontend
 version: 0.2.30
 apiVersion: v2
 dependencies:
+- name: mariadb
+  version: 7.10.x
+  repository: https://charts.bitnami.com/bitnami
+  condition: mariadb.enabled
 - name: elasticsearch
   version: 7.4.1
   repository: https://helm.elastic.co

--- a/charts/frontend/README.md
+++ b/charts/frontend/README.md
@@ -7,6 +7,7 @@ This chart is used to deploy a frontend application, typically as a decoupled fr
 Service containers have following environment variables:
   - Variables defined in silta.yml `php.env`
   - PORT: TCP port local service is running on. This is taken from silta.yml `service.customservice.port`;
+  - PROJECT_NAME: Project name. Defaults to github repository name (i.e. "charts").
   - ENVIRONMENT_DOMAIN: Pre-generated domain name of current deployment (without protocol prefix);
   - RELEASE_NAME: Normalised and trimmed branch name (i.e. `dependabot-npm-and-yarn-apollo-serv-e6b3`);
   - *_HOST: Server host addresses of all services in current deployment, including port. (i.e. `dependabot-npm-and-yarn-apollo-serv-e6b3-node:3000`).
@@ -14,3 +15,8 @@ Service containers have following environment variables:
     - ELASTICSEARCH_HOST: Elasticsearch server host.
   - When RabbitMQ is enabled:
     - RABBITMQ_HOST: RabbitMQ server host.
+  - When MariaDB is enabled:
+      - DB_HOST: Database server host. 
+      - DB_USER: Database username. Uses silta.yml `mariadb.db.user`, default value provided by build process.
+      - DB_PASS: Database password. Uses silta.yml `mariadb.db.password` default value provided by build process
+      - DB_NAME: Database name. Set to "frontend" by default.

--- a/charts/frontend/templates/_overrides.tpl
+++ b/charts/frontend/templates/_overrides.tpl
@@ -24,3 +24,11 @@ The rabbitmq chart has some unconventional naming logic, we prefer to keep thing
 {{- define "rabbitmq.fullname" -}}
 {{ .Release.Name }}-rabbitmq
 {{- end -}}
+
+{{/*
+The mariadb chart switched to an incompatible naming scheme,
+we make it compatible by overriding the following templates.
+*/}}
+{{- define "mariadb.fullname" -}}
+{{ .Release.Name }}-mariadb
+{{- end }}

--- a/charts/frontend/templates/services-deployment.yaml
+++ b/charts/frontend/templates/services-deployment.yaml
@@ -57,6 +57,8 @@ spec:
         {{- end }}
         - name: 'PORT'
           value: {{ default $.Values.serviceDefaults.port $service.port | quote }}
+        - name: PROJECT_NAME
+          value: "{{ $.Values.projectName | default $.Release.Namespace }}"
         - name: 'ENVIRONMENT_DOMAIN'
           value: {{ template "frontend.domain" $ }}
         - name: 'RELEASE_NAME'
@@ -64,6 +66,19 @@ spec:
         {{- range $index, $service := $.Values.services }}
         - name: "{{ $index }}_HOST"
           value: "{{ $.Release.Name }}-{{ $index }}:{{ default $.Values.serviceDefaults.port $service.port }}"
+        {{- end }}
+        {{- if $.Values.mariadb.enabled }}
+        - name: DB_USER
+          value: "{{ $.Values.mariadb.db.user }}"
+        - name: DB_NAME
+          value: "{{ $.Values.mariadb.db.name }}"
+        - name: DB_HOST
+          value: {{ $.Release.Name }}-mariadb
+        - name: DB_PASS
+          valueFrom:
+            secretKeyRef:
+              name: {{ $.Release.Name }}-mariadb
+              key: mariadb-password
         {{- end }}
         {{- if $.Values.elasticsearch.enabled }}
         - name: ELASTICSEARCH_HOST
@@ -118,6 +133,52 @@ spec:
         {{- $service.nodeSelector | toYaml | nindent 8 }}
       tolerations:
         {{- include "frontend.tolerations" $service.nodeSelector | nindent 8 }}
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          # Preferrably keep pods on the same node as the database.
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: release
+                  operator: In
+                  values:
+                  - "{{ $.Release.Name }}"
+                - key: mariadb
+                  operator: In
+                  values:
+                  - mariadb
+              topologyKey: kubernetes.io/hostname
+          # Preferrably keep pods in the same zone as the database.
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: release
+                  operator: In
+                  values:
+                  - "{{ $.Release.Name }}"
+                - key: mariadb
+                  operator: In
+                  values:
+                  - mariadb
+              topologyKey: topology.kubernetes.io/zone
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 10
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: release
+                  operator: In
+                  values:
+                  - "{{ $.Release.Name }}"
+                - key: deployment
+                  operator: In
+                  values:
+                  - frontend-{{ $index }}
       {{- end }}
 
 {{- if $service.autoscaling }}

--- a/charts/frontend/tests/mariadb_test.yaml
+++ b/charts/frontend/tests/mariadb_test.yaml
@@ -1,0 +1,28 @@
+suite: MariaDB
+templates:
+  - services-deployment.yaml
+  - configmap.yaml
+tests:
+  - it: sets mariadb user in service environment if mariadb explicitly enabled
+    set:
+      mariadb.enabled: true
+      mariadb.db.user: testuser
+      services.foo.bar: yes
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_USER
+            value: testuser
+
+  - it: sets no mariadb user in service environment if mariadb disabled
+    set:
+      mariadb.enabled: false
+      mariadb.db.user: testuser
+      services.foo.bar: yes
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_USER
+            value: testuser

--- a/charts/frontend/tests/volumes_test.yaml
+++ b/charts/frontend/tests/volumes_test.yaml
@@ -1,4 +1,4 @@
-suite: drupal volumes
+suite: Data volumes
 templates:
   - volumes.yaml
 tests:

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -206,6 +206,38 @@ serviceDefaults:
           name: cpu
           targetAverageUtilization: 80
 
+# Override the default values of the MariaDB subchart.
+# These settings are optimised for development environments.
+# see: https://github.com/bitnami/charts/blob/master/bitnami/mariadb/values.yaml
+mariadb:
+  enabled: false
+  replication:
+    enabled: false
+  db:
+    name: frontend
+    user: frontend
+  master:
+    persistence:
+      # Database storage disk space allocation
+      # Request assistance from ops team after changing this on existing deployment.
+      size: 1G
+    resources:
+      requests:
+        cpu: 25m
+        memory: 384M
+      limits:
+        memory: 512M
+    affinity:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+            - key: cloud.google.com/gke-nodepool
+              operator: NotIn
+              values:
+              - static-ip
+
 elasticsearch:
   enabled: false
 

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -52,3 +52,6 @@ shell:
 silta-release:
   proxy:
     enabled: true
+
+mariadb:
+  enabled: true


### PR DESCRIPTION
Allows having mariadb server (disabled by default) via https://github.com/bitnami/charts/tree/master/bitnami/mariadb subchart

Enabling:
```
mariadb:
  enabled: true
```

Testing:
```
[apk add mysql-client]
echo "SHOW DATABASES" | mysql -u $DB_USER -h $DB_HOST -p$DB_PASS $DB_NAME
```