### PR TITLE
Environment variable template

### DIFF
--- a/charts/frontend/templates/services-cron.yaml
+++ b/charts/frontend/templates/services-cron.yaml
@@ -37,28 +37,10 @@ spec:
               {{- end }}
               {{- end }}
             env:
-            {{- include "services.env" $ | nindent 12 }}
+            {{- include "services.env" (dict "Values" $.Values "Release" $.Release "service" $service) | nindent 12 }}
             {{- range $key, $val := $service.env }}
             - name: {{ $key }}
               value: {{ $val | quote }}
-            {{- end }}
-            - name: 'PORT'
-              value: {{ default $.Values.serviceDefaults.port $service.port | quote }}
-            - name: 'ENVIRONMENT_DOMAIN'
-              value: {{ template "frontend.domain" $ }}
-            - name: 'RELEASE_NAME'
-              value: {{ $.Release.Name | quote }}
-            {{- range $index, $service := $.Values.services }}
-            - name: "{{ $index }}_HOST"
-              value: "{{ $.Release.Name }}-{{ $index }}:{{ default $.Values.serviceDefaults.port $service.port }}"
-            {{- end }}
-            {{- if $.Values.elasticsearch.enabled }}
-            - name: ELASTICSEARCH_HOST
-              value: {{ $.Release.Name }}-es
-            {{- end }}
-            {{- if $.Values.rabbitmq.enabled }}
-            - name: RABBITMQ_HOST
-              value: {{ $.Release.Name }}-rabbitmq
             {{- end }}
             command: ["/bin/sh", "-c"]
             args:

--- a/charts/frontend/templates/services-deployment.yaml
+++ b/charts/frontend/templates/services-deployment.yaml
@@ -50,61 +50,10 @@ spec:
           tcpSocket:
             port: {{ default $.Values.serviceDefaults.port $service.port }}
         env:
-        {{- include "services.env" $ | indent 8 }}
+        {{- include "services.env" (dict "Values" $.Values "Release" $.Release "service" $service) | nindent 8 }}
         {{- range $key, $val := $service.env }}
         - name: {{ $key }}
           value: {{ $val | quote }}
-        {{- end }}
-        - name: 'PORT'
-          value: {{ default $.Values.serviceDefaults.port $service.port | quote }}
-        - name: PROJECT_NAME
-          value: "{{ $.Values.projectName | default $.Release.Namespace }}"
-        - name: 'ENVIRONMENT_DOMAIN'
-          value: {{ template "frontend.domain" $ }}
-        - name: 'RELEASE_NAME'
-          value: {{ $.Release.Name | quote }}
-        {{- range $index, $service := $.Values.services }}
-        - name: "{{ $index }}_HOST"
-          value: "{{ $.Release.Name }}-{{ $index }}:{{ default $.Values.serviceDefaults.port $service.port }}"
-        {{- end }}
-        {{- if $.Values.mariadb.enabled }}
-        - name: DB_USER
-          value: "{{ $.Values.mariadb.db.user }}"
-        - name: DB_NAME
-          value: "{{ $.Values.mariadb.db.name }}"
-        - name: DB_HOST
-          value: {{ $.Release.Name }}-mariadb
-        - name: DB_PASS
-          valueFrom:
-            secretKeyRef:
-              name: {{ $.Release.Name }}-mariadb
-              key: mariadb-password
-        {{- end }}
-        {{- if $.Values.elasticsearch.enabled }}
-        - name: ELASTICSEARCH_HOST
-          value: {{ $.Release.Name }}-es
-        {{- end }}
-        {{- if $.Values.rabbitmq.enabled }}
-        - name: RABBITMQ_HOST
-          value: {{ $.Release.Name }}-rabbitmq
-        {{- end }}
-        {{ if $.Values.shell.enabled -}}
-        - name: GITAUTH_URL
-          value: {{ $.Values.shell.gitAuth.keyserver.url | default (printf "https://keys.%s/api/1/git-ssh-keys" $.Values.clusterDomain) | quote }}
-        - name: GITAUTH_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: {{ $.Release.Name }}-secrets-shell
-              key: keyserver.username
-        - name: GITAUTH_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ $.Release.Name }}-secrets-shell
-              key: keyserver.password
-        - name: GITAUTH_SCOPE
-          value: {{ $.Values.shell.gitAuth.repositoryUrl }}
-        - name: OUTSIDE_COLLABORATORS
-          value: {{ $.Values.shell.gitAuth.outsideCollaborators | default true | quote }} 
         {{- end }}
         resources:
           {{ if $service.resources -}}


### PR DESCRIPTION
Cronjob was missing new mariadb environment variables and since service deployment and cron templates looked terrible, I decided to move env definitions into _helpers template. 

Sorted out the template context with dict and passing trough `Values` and `Release` in addition to `$service`