### PR TITLE
Ingress aggregation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,8 @@ workflows:
           name: 'Validate frontend chart'
 
       - silta/frontend-build-deploy: &build-deploy
+          requires:
+            - 'Validate frontend chart'
           name: 'Silta build & deploy'
 
           executor: silta-latest

--- a/charts/frontend/templates/NOTES.txt
+++ b/charts/frontend/templates/NOTES.txt
@@ -1,4 +1,4 @@
-{{ $protocol := .Values.ssl.enabled | ternary "https" "http" -}}
+{{ $protocol := .Values.ingress.default.tls | ternary "https" "http" -}}
 Deployed {{ .Release.Name }} successfully, your site is available here:
 
 {{ range $index, $service := .Values.services -}}

--- a/charts/frontend/templates/NOTES.txt
+++ b/charts/frontend/templates/NOTES.txt
@@ -1,8 +1,8 @@
 {{ $protocol := .Values.ingress.default.tls | ternary "https" "http" -}}
 Deployed {{ .Release.Name }} successfully, your site is available here:
 
-{{ range $index, $service := .Values.services -}}
-  {{ if $service.exposedRoute }}
+  {{ range $index, $service := .Values.services -}}
+  {{- if $service.exposedRoute }}
   {{ $protocol }}://{{- template "frontend.domain" $ }}{{ $service.exposedRoute }}
   {{- range $index, $prefix := $.Values.domainPrefixes }}
   {{ $protocol}}://{{$prefix}}.{{- template "frontend.domain" $ }}{{ $service.exposedRoute }}
@@ -11,25 +11,25 @@ Deployed {{ .Release.Name }} successfully, your site is available here:
   {{ $protocol }}://{{ $domain.hostname }}{{ $service.exposedRoute }}
   {{- end -}}
   {{- end -}}
-{{- end }}
+  {{- end }}
 
-{{ if .Values.nginx.basicauth.enabled -}}
-Basicauth username: {{ .Values.nginx.basicauth.credentials.username }}
-Basicauth password: {{ .Values.nginx.basicauth.credentials.password }}
-{{- end }}
+  {{ if .Values.nginx.basicauth.enabled -}}
+  Basicauth username: {{ .Values.nginx.basicauth.credentials.username }}
+  Basicauth password: {{ .Values.nginx.basicauth.credentials.password }}
+  {{- end }}
+
 {{ if $.Values.shell.enabled }}
 SSH connection (limited access through VPN):
   {{ range $index, $service := .Values.services }}
-      ssh www-admin@{{ template "frontend.environment.hostname" $ }}-shell-{{ $index }}.{{ $.Release.Namespace }} -J {{ include "frontend.jumphost" $ }}
+  ssh www-admin@{{ template "frontend.environment.hostname" $ }}-shell-{{ $index }}.{{ $.Release.Namespace }} -J {{ include "frontend.jumphost" $ }}
   {{- end }}
 
   {{ range $index, $service := .Values.services -}}
-    {{ if $service.mounts }}
-      {{ range $indexMount, $service.mounts -}}
-Importing files to service '{{ $index }}', folder '{{ (index $.Values.mounts $indexMount).mountPath }}':
+  {{- if $service.mounts }}
+  {{- range $indexMount, $service.mounts -}}
+  Importing files to service '{{ $index }}', folder '{{ (index $.Values.mounts $indexMount).mountPath }}':
 rsync -azv -e 'ssh -A -J {{ include "frontend.jumphost" $ }}' local_folder/ www-admin@{{ template "frontend.environment.hostname" $ }}-shell-{{ $index }}.{{ $.Release.Namespace }}:{{ (index $.Values.mounts $indexMount).mountPath }}
-
-      {{ end -}}
-    {{ end -}}
+  {{ end -}}
+  {{ end -}}
   {{ end -}}
 {{- end -}}

--- a/charts/frontend/templates/certificate.yaml
+++ b/charts/frontend/templates/certificate.yaml
@@ -1,5 +1,7 @@
-{{- if .Values.ssl.enabled }}
-{{- if has .Values.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
+{{- $context_ingress := .Values.ingress.default }}
+{{- $context_ssl := .Values.ssl }}
+{{- if $context_ingress.tls }}
+{{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
@@ -11,7 +13,7 @@ spec:
   dnsNames:
   - {{ template "frontend.domain" . }}
   issuerRef:
-    name: {{ .Values.ssl.issuer }}
+    name: {{ $context_ssl.issuer }}
     kind: ClusterIssuer
   acme:
     config:
@@ -32,7 +34,7 @@ spec:
   dnsNames:
   - {{$prefix}}.{{ template "frontend.domain" $ }}
   issuerRef:
-    name: {{ $.Values.ssl.issuer }}
+    name: {{ $context_ssl.issuer }}
     kind: ClusterIssuer
   acme:
     config:
@@ -43,7 +45,7 @@ spec:
 ---
 {{- end }}
 
-{{- else if eq .Values.ssl.issuer "selfsigned" }}
+{{- else if eq $context_ssl.issuer "selfsigned" }}
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
@@ -58,11 +60,11 @@ spec:
   dnsNames:
   - {{ template "frontend.domain" . }}
   issuerRef:
-    name: {{ .Values.ssl.issuer }}
+    name: {{ $context_ssl.issuer }}
     kind: ClusterIssuer
 ---
 
-{{- else if eq .Values.ssl.issuer "custom" }}
+{{- else if eq $context_ssl.issuer "custom" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -71,8 +73,9 @@ metadata:
     {{- include "frontend.release_labels" . | nindent 4 }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ .Values.ssl.crt | b64enc }}
-  tls.key: {{ .Values.ssl.key | b64enc }}
+  tls.ca: {{ $context_ssl.ca | b64enc }}
+  tls.crt: {{ $context_ssl.crt | b64enc }}
+  tls.key: {{ $context_ssl.key | b64enc }}
 ---
 {{- end }}
 

--- a/charts/frontend/templates/configmap.yaml
+++ b/charts/frontend/templates/configmap.yaml
@@ -68,7 +68,10 @@ data:
 
         map $uri $no_slash_uri {                                                                                                                           
             ~^/(?<no_slash>.*)$ $no_slash;                                                                                                                 
-        }                                                            
+        }
+
+        # List health checks that need to return status 200 here
+        map $http_user_agent $hc_ua { default 0; 'GoogleHC/1.0' 1; }                                                             
                                                                                                                                                           
         include conf.d/*.conf;                                                                                                                             
     }     
@@ -102,6 +105,9 @@ data:
     server {                               
         server_name frontend;
         listen 80;
+
+        # Loadbalancer health checks need to be fed with http 200 
+        if ($hc_ua) { return 200; }
 
         {{- if .Values.nginx.redirects }}
         # Redirects to specified path if map returns anything

--- a/charts/frontend/templates/ingress.yaml
+++ b/charts/frontend/templates/ingress.yaml
@@ -1,15 +1,28 @@
+{{- $ingress := .Values.ingress.default }}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-nginx
   annotations:
-    kubernetes.io/ingress.class: traefik
-    {{- if .Values.ssl.enabled }}
+    kubernetes.io/ingress.class: {{ $ingress.type | quote }}
+    {{- if $ingress.tls }}
+    certmanager.k8s.io/acme-http01-edit-in-place: "true"
+    {{- if eq $ingress.type "traefik" }}
     traefik.ingress.kubernetes.io/frontend-entry-points: "http,https"
-    ingress.kubernetes.io/ssl-redirect: "true"
+    {{- end }}
     {{- else }}
+    {{- if eq $ingress.type "traefik" }}
     traefik.ingress.kubernetes.io/frontend-entry-points: "http"
-    ingress.kubernetes.io/ssl-redirect: "false"
+    {{- end }}
+    {{- end }}
+    {{- if (hasKey $ingress "redirect-https") }}
+    ingress.kubernetes.io/ssl-redirect: {{ (index $ingress "redirect-https") | quote }}
+    {{- end }}
+    {{- if eq $ingress.type "gce" }}
+    cert-manager.io/cluster-issuer: letsencrypt
+    {{- end }}
+    {{- if $ingress.staticIpAddressName }}
+    kubernetes.io/ingress.global-static-ip-name: {{ $ingress.staticIpAddressName | quote }}
     {{- end }}
 
     {{- if (index .Values "silta-release").downscaler.enabled }}
@@ -20,7 +33,7 @@ metadata:
   labels:
     {{ include "frontend.release_labels" . | indent 4 }}
 spec:
-  {{- if .Values.ssl.enabled }}
+  {{- if $ingress.tls }}
   tls:
   - secretName: {{ .Release.Name }}-tls
   {{- range $index, $prefix := .Values.domainPrefixes }}
@@ -36,7 +49,7 @@ spec:
           serviceName: {{ .Release.Name }}-nginx
           servicePort: 80
 {{- range $index, $prefix := .Values.domainPrefixes }}
-  - host: {{$prefix}}.{{ template "frontend.domain" $ }}
+  - host: {{ $prefix }}.{{ template "frontend.domain" $ }}
     http:
       paths:
       - path: /
@@ -45,39 +58,74 @@ spec:
           servicePort: 80
 {{- end }}
 ---
-{{- range $index, $domain := .Values.exposeDomains }}
+# Ingresses for exposeDomains 
+{{- range $ingress_index, $ingress := $.Values.ingress }}
+
+{{- $ingress := mergeOverwrite (deepCopy $.Values.ingress.default) $ingress }}
+
+{{- $ingress_in_use := false }}
+{{- range $domain_index, $domain := $.Values.exposeDomains }}
+  {{- $domain := mergeOverwrite (deepCopy $.Values.exposeDomainsDefaults) $domain }}
+  {{- if $domain.ingress }}
+    {{- if eq $ingress_index $domain.ingress }}
+      {{- $ingress_in_use = true }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- if $ingress_in_use }}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: {{ $.Release.Name }}-nginx-{{ $index }}
+  name: {{ $.Release.Name }}-nginx-{{ $ingress_index }}
   annotations:
-    kubernetes.io/ingress.class: traefik
-    {{- if $domain.ssl }}
-    {{- if $domain.ssl.enabled }}
-    traefik.ingress.kubernetes.io/frontend-entry-points: http,https
-    ingress.kubernetes.io/ssl-redirect: "true"
+    kubernetes.io/ingress.class: {{ $ingress.type | quote }}
+    {{- if $ingress.tls }}
+    certmanager.k8s.io/acme-http01-edit-in-place: "true"
+    {{- if eq $ingress.type "traefik" }}
+    traefik.ingress.kubernetes.io/frontend-entry-points: "http,https"
     {{- end }}
     {{- else }}
-    traefik.ingress.kubernetes.io/frontend-entry-points: http
-    ingress.kubernetes.io/ssl-redirect: "false"
+    {{- if eq $ingress.type "traefik" }}
+    traefik.ingress.kubernetes.io/frontend-entry-points: "http"
+    {{- end }}
+    {{- end }}
+    {{- if (hasKey $ingress "redirect-https") }}
+    ingress.kubernetes.io/ssl-redirect: {{ (index $ingress "redirect-https") | quote }}
+    {{- end }}
+    {{- if eq $ingress.type "gce" }}
+    cert-manager.io/cluster-issuer: letsencrypt
+    {{- end }}
+    {{- if $ingress.staticIpAddressName }}
+    kubernetes.io/ingress.global-static-ip-name: {{ $ingress.staticIpAddressName | quote }}
     {{- end }}
   labels:
     {{ include "frontend.release_labels" $ | indent 4 }}
 spec:
+  tls:
+  {{- range $domain_index, $domain := $.Values.exposeDomains }}
+  {{- $domain := mergeOverwrite (deepCopy $.Values.exposeDomainsDefaults) $domain }}
+  {{- if eq $domain.ingress $ingress_index }}
   {{- if $domain.ssl }}
   {{- if $domain.ssl.enabled }}
-  tls:
-  - secretName: {{ $.Release.Name }}-tls-{{ $index }}
+  - secretName: {{ $.Release.Name }}-tls-{{ $domain_index }}
+  {{- end }}
+  {{- end }}
   {{- end }}
   {{- end }}
   rules:
+  {{- range $domain_index, $domain := $.Values.exposeDomains }}
+  {{- $domain := mergeOverwrite (deepCopy $.Values.exposeDomainsDefaults) $domain }}
+  {{- if eq $domain.ingress $ingress_index }}
   - host: {{ $domain.hostname }}
     http:
       paths:
-      - path: /
+      - path: {{ if eq $ingress.type "gce" }}/*{{ else }}/{{ end }}
         backend:
           serviceName: {{ $.Release.Name }}-nginx
           servicePort: 80
+  {{- end }}
+  {{- end }}
 ---
 {{- end }}
-
+{{- end }}

--- a/charts/frontend/templates/service.yaml
+++ b/charts/frontend/templates/service.yaml
@@ -6,6 +6,8 @@ metadata:
     {{ include "frontend.release_labels" . | indent 4 }}
   annotations:
       auto-downscale/down: "false"
+      beta.cloud.google.com/backend-config: '{"ports": {"80":"{{ .Release.Name }}-nginx"}}'
+      cloud.google.com/neg: '{"ingress": true}'
 spec:
   type: NodePort
   externalTrafficPolicy: Local

--- a/charts/frontend/tests/ingress_test.yaml
+++ b/charts/frontend/tests/ingress_test.yaml
@@ -88,3 +88,118 @@ tests:
       - equal:
          path: spec.rules[2].host
          value: 'quux.foo.bar.baz'
+
+  - it: exposeDomains - uses default ingress type and has correct hostname
+    template: ingress.yaml
+    set:
+      ingress:
+        default:
+          type: foo
+      exposeDomains:
+        bar:
+          hostname: bar.baz
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: 'metadata.annotations.kubernetes\.io/ingress\.class'
+          value: 'foo'
+  
+  - it: exposeDomains - has correct hostname
+    template: ingress.yaml
+    set:
+      exposeDomains:
+        bar:
+          hostname: foo.bar
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.rules[0].host
+          value: 'foo.bar'
+
+  - it: exposeDomains - can disable ssl for a certain ingress
+    template: ingress.yaml
+    set:
+      ingress:
+        nossl:
+          tls: false
+          redirect-https: false
+      exposeDomains:
+        foo:
+          hostname: foo.bar
+          ingress: nossl
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: 'metadata.annotations.traefik\.ingress\.kubernetes\.io\/frontend-entry-points'
+          value: 'http'
+      - documentIndex: 1
+        equal:
+          path: 'ingress\.kubernetes\.io\/ssl-redirect'
+          value: null
+
+  - it: exposeDomains - can disable ssl redirect
+    template: ingress.yaml
+    set:
+      ingress:
+        nossl:
+          redirect-https: false
+      exposeDomains:
+        foo:
+          hostname: foo.bar
+          ingress: nossl
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: 'metadata.annotations.ingress\.kubernetes\.io\/ssl-redirect'
+          value: "false"
+
+  - it: exposeDomains - multiple hostnames can use the same ingress 
+    template: ingress.yaml
+    set:
+      exposeDomains:
+        foo:
+          hostname: foo.baz
+        bar:
+          hostname: bar.baz
+        
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: 'spec.rules[1].host'
+          value: 'foo.baz'
+      - documentIndex: 1
+        equal:
+          path: 'spec.rules[0].host'
+          value: 'bar.baz'
+
+  - it: exposeDomains as list, multiple hostnames can use the same ingress [list definition to be deprecated]
+    template: ingress.yaml
+    set:
+      exposeDomains:
+        - hostname: foo.baz
+        - hostname: bar.baz
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: 'spec.rules[0].host'
+          value: 'foo.baz'
+      - documentIndex: 1
+        equal:
+          path: 'spec.rules[1].host'
+          value: 'bar.baz'
+
+  - it: exposeDomains - can supply staticIpAddressName for gce type ingress
+    template: ingress.yaml
+    set:
+      exposeDomains:
+        bar:
+          hostname: foo.bar
+          ingress: gce
+      ingress:
+        gce:
+          staticIpAddressName: baz
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: 'metadata.annotations.kubernetes\.io\/ingress\.global-static-ip-name'
+          value: 'baz'

--- a/charts/frontend/values.schema.json
+++ b/charts/frontend/values.schema.json
@@ -9,9 +9,11 @@
     "imagePullSecrets": { "type": "array" },
     "app": { "type": "string" },
     "exposeDomains": { "type": ["array","object"], "items": { "type": "object"}},
+    "exposeDomainsDefaults": { "type": "object"},
     "domainPrefixes": { "type": "array", "items": { "type": "string"}},
     "ssl": { "type": "object" },
-
+    "backendConfig": { "type": ["array","object"], "items": { "type": "object"}},
+    "ingress": { "type": "object" },
     "nginx": { "type": "object" },
     "services": { "type": "object" },
     "serviceDefaults": { "type": "object" },

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -21,21 +21,29 @@ environmentName: ""
 app: frontend
 
 # Domain names that will be mapped to this deployment.
-# Example of exposing 2 additional domains for this deployment, each with its own certificate
-# Note that the key is only used for documentation purposes.
+# Example of exposing 2 additional domains for this deployment, each with its own certificate.
 # exposeDomains:
-#   - hostname: example.com
-#   - hostname: www.example.com
-#   -   ssl:
-#   -     enabled: true
-#   -     issuer: letsencrypt-staging
+#   example:
+#     hostname: example.com
+#   example2:
+#     hostname: example1.com
+#     # Reference to a key under `ingress`
+#     ingress: gce
+#     ssl:
+#       enabled: true
+#       issuer: letsencrypt-staging
+#   example_www:
+#     hostname: www.example.com
+#   example_no_https:
+#    hostname: insecure.example.com
+#      ssl: 
+#        enabled: false
 exposeDomains: {}
 
-# Add prefixes to the generated per-branch domains, to be used for projects that need to respond
-# on multiple domains.
-# domainPrefixes: ['en', 'fi']
-domainPrefixes: []
+exposeDomainsDefaults:
+  ingress: default
 
+# Settings for default site provided by this deployment
 ssl:
   # Enable HTTPS for this deployment
   enabled:  true
@@ -45,6 +53,27 @@ ssl:
   # ca: ""
   # key: ""
   # crt: ""
+
+ingress:
+  default:
+    type: traefik
+    tls: true
+    redirect-https: true
+  gce:
+    type: gce
+    # The name of the reserved static IP address.
+    # It is best to first reserve the IP address and then add it here.
+    # staticIpAddressName: null
+
+# backendConfig customizations for main service
+backendConfig:
+  securityPolicy:
+    name: "silta-ingress"
+
+# Add prefixes to the generated per-branch domains, to be used for projects that need to respond
+# on multiple domains.
+# domainPrefixes: ['en', 'fi']
+domainPrefixes: []
 
 # These variables are build-specific and should be passed via the --set parameter.
 nginx:


### PR DESCRIPTION
This PR:
- Deploy only if chart validation step succeeds (only affects this project)
- Force return 200 for GCE ingress health checks
- aggregates exposeDomains into ingresses (no more index per exposeDomain)
- Adds ingress definition (and deprecates exposeDomains.domain.type)
- Promotes map definition instead of list for exposeDomains
- Adds test cases for things above
