### PR TITLE
SLT-523: User definable postrelease tasks

### DIFF
--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: frontend
-version: 0.2.36
+version: 0.2.38
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/charts/frontend/templates/services-deployment.yaml
+++ b/charts/frontend/templates/services-deployment.yaml
@@ -21,6 +21,9 @@ spec:
         {{ if $.Values.shell.enabled -}}
         silta-ingress: allow
         {{- end }}
+      annotations:
+        # We use a checksum to redeploy the pods when the configMap changes.
+        configMap-checksum: {{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum }}
     spec:
       enableServiceLinks: false
       containers:
@@ -159,6 +162,9 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |
+            {{ if $.Release.IsInstall }}
+            {{ $service.postinstall.command }}
+            {{ end }}
             {{ $service.postupgrade.command }}
         volumeMounts:
           {{ if $service.mounts }}

--- a/charts/frontend/templates/services-deployment.yaml
+++ b/charts/frontend/templates/services-deployment.yaml
@@ -132,7 +132,7 @@ spec:
                   values:
                   - frontend-{{ $index }}
       {{- end }}
-{{- if $service.postupgrade }}
+{{- if or $service.postupgrade $service.postinstall }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -162,9 +162,9 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |
-            {{ if $.Release.IsInstall }}
+            {{- if $.Release.IsInstall }}
             {{ $service.postinstall.command }}
-            {{ end }}
+            {{- end }}
             {{ $service.postupgrade.command }}
         volumeMounts:
           {{ if $service.mounts }}

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -185,6 +185,12 @@ services: {}
   #     limits:
   #       memory: 512Mi
 
+  #  # Post-install hook.
+  #  # This is run every time a new environment (most commonly a first deployment for a new branch) is created
+  #  postinstall:
+  #    command: |
+  #      'your command here'
+
   #  # Post-release hook.
   #  # This is run every time a new release is deployed
   #  postupgrade:

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -189,13 +189,13 @@ services: {}
   #  # This is run every time a new environment (most commonly a first deployment for a new branch) is created
   #  postinstall:
   #    command: |
-  #      'your command here'
+  #      your command goes here
 
-  #  # Post-release hook.
+  #  # Post-upgrade hook.
   #  # This is run every time a new release is deployed
   #  postupgrade:
   #    command: |
-  #      'your command here'
+  #      your command goes here
 
   #  cron:
   #    example:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -10,18 +10,18 @@ nginx:
       from: /
       to: /hello
 
-services: 
+services:
   hello:
     exposedRoute: '/hello'
     port: 4000
     env:
       FOO: 'BAR'
-    postupgrade:
-      command: |
-        echo Testing postupgrade job 2nd
     postinstall:
       command: |
-        echo Testing postinstall job 2nd
+        echo Postinstall command executed
+    postupgrade:
+      command: |
+        echo Postupgrade command executed
 
   world:
     exposedRoute: '/world'

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -18,7 +18,10 @@ services:
       FOO: 'BAR'
     postupgrade:
       command: |
-        echo Testing postrelease job
+        echo Testing postupgrade job 2nd
+    postinstall:
+      command: |
+        echo Testing postinstall job 2nd
 
   world:
     exposedRoute: '/world'


### PR DESCRIPTION
Adds two custom jobs to be defined by the user:
1. Postinstall - executes after a new environment is made (common case is first deployment for a new branch);
2. Postupgrade - executes after each deployment.

Testing:
1. Create postinstall,postupgrade tasks for a service
2. Both of these tasks execute on the first deployment - check post-release pod logs.
3. Subsequent deployments only execute postrelease.