### PR TITLE
exposeDomains certificate ingress fix

### DIFF
--- a/charts/frontend/templates/certificate.yaml
+++ b/charts/frontend/templates/certificate.yaml
@@ -102,7 +102,7 @@ spec:
   acme:
     config:
       - http01:
-          ingress: {{ $.Release.Name }}-nginx
+          ingress: {{ $.Release.Name }}-nginx-{{ $domain.ingress }}
         domains:
           - {{ $domain.hostname }}
 ---


### PR DESCRIPTION
Pointing exposeDomains certificate at the correct ingress for acme validations to succeed