### PR TITLE
Add security headers under exposedRoutes.

### DIFF
--- a/charts/frontend/templates/_helpers.tpl
+++ b/charts/frontend/templates/_helpers.tpl
@@ -17,6 +17,18 @@ release: {{ .Release.Name }}
   {{- end }}
 {{- end }}
 
+{{- define "frontend.security_headers" }}
+  ## https://www.owasp.org/index.php/List_of_useful_HTTP_headers.
+  add_header    X-Frame-Options SAMEORIGIN;
+  add_header    X-Content-Type-Options nosniff;
+  add_header    Strict-Transport-Security "max-age=31536000; {{ .Values.nginx.hsts_include_subdomains }} preload" always;
+  {{- if .Values.nginx.content_security_policy }}
+  add_header    Content-Security-Policy "{{ .Values.nginx.content_security_policy }}" always;
+  {{- end }}
+  add_header    X-XSS-Protection "1; mode=block";
+  add_header    Referrer-Policy "no-referrer, strict-origin-when-cross-origin" always;
+{{- end }}
+
 {{- define "frontend.tolerations" -}}
 {{- range $key, $label := $ }}
 - key: {{ $key }}

--- a/charts/frontend/templates/configmap.yaml
+++ b/charts/frontend/templates/configmap.yaml
@@ -59,15 +59,7 @@ data:
         gzip_proxied                any;       
         gzip_disable                msie6;                                                                                                                 
                                                                                                                                                           
-        ## https://www.owasp.org/index.php/List_of_useful_HTTP_headers.
-        add_header                  X-Frame-Options SAMEORIGIN;                                                                                            
-        add_header                  X-Content-Type-Options nosniff;
-        add_header                  Strict-Transport-Security "max-age=31536000; {{ .Values.nginx.hsts_include_subdomains }} preload" always;
-        {{- if .Values.nginx.content_security_policy }}
-        add_header                  Content-Security-Policy "{{ .Values.nginx.content_security_policy }}" always;
-        {{- end }}
-        add_header                  X-XSS-Protection "1; mode=block";
-        add_header                  Referrer-Policy "no-referrer, strict-origin-when-cross-origin" always;
+        {{ include "frontend.security_headers" $ | indent 4 }}
 
         map_hash_bucket_size 128;
 
@@ -195,7 +187,9 @@ data:
           proxy_set_header        X-Forwarded-Proto $scheme;
           proxy_set_header        X-Forwarded-Port  $server_port;
           add_header              Front-End-Https   on;
-          
+
+          {{ include "frontend.security_headers" $ | indent 6 }}
+    
           {{- range $header_name, $header_value := $.Values.nginx.extra_headers }}
           add_header {{ $header_name }} {{ $header_value }};
           {{- end }}


### PR DESCRIPTION
We have standard security headers defined in global level, but Nginx overrides all headers when set on a lower level block like `location`. We have additional headers set in exposedRoute location block with the possibility to even add extra headers there. This causes our default security headers often missing from projects due developers not knowing/remembering to add them.
This pull request adds the security headers also under the exposeRoute block so we will always have the default security headers present. The security headers can be adjusted the same way as the global ones.
How to test:
Check that the security headers are present on the exposed routes (e.g. https://feature-exposedroutesecheaders.frontend-project-k8s.dev.wdr.io/hello and https://feature-exposedroutesecheaders.frontend-project-k8s.dev.wdr.io/world). 
Expected header values that should be present:
```
referrer-policy: no-referrer, strict-origin-when-cross-origin
strict-transport-security: max-age=31536000;  preload
x-content-type-options: nosniff
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block
```
 