### PR TITLE
Feature/ingress v1 api

### DIFF
--- a/charts/frontend/templates/_helpers.tpl
+++ b/charts/frontend/templates/_helpers.tpl
@@ -124,9 +124,8 @@ rsync -az /values_mounts/ /backups/current/
 
 {{- define "cert-manager.api-version" }}
 {{- if ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
-apiVersion: cert-manager.io/v1
+cert-manager.io/v1
 {{- else }}
-apiVersion: certmanager.k8s.io/v1alpha1
+certmanager.k8s.io/v1alpha1
 {{- end }}
 {{- end }}
-

--- a/charts/frontend/templates/_helpers.tpl
+++ b/charts/frontend/templates/_helpers.tpl
@@ -129,3 +129,11 @@ cert-manager.io/v1
 certmanager.k8s.io/v1alpha1
 {{- end }}
 {{- end }}
+
+{{- define "ingress.api-version" }}
+{{- if semverCompare ">=1.18" .Capabilities.KubeVersion.Version }}
+networking.k8s.io/v1
+{{- else }}
+networking.k8s.io/v1beta1
+{{- end }}
+{{- end }}

--- a/charts/frontend/templates/certificate.yaml
+++ b/charts/frontend/templates/certificate.yaml
@@ -2,7 +2,7 @@
 {{- $context_ssl := .Values.ssl }}
 {{- if $context_ingress.tls }}
 {{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-{{- include "cert-manager.api-version" . }}
+apiVersion: {{ include "cert-manager.api-version" . | trim }}
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-crt
@@ -18,7 +18,7 @@ spec:
   issuerRef:
     name: {{ $context_ssl.issuer }}
     kind: ClusterIssuer
-{{- if not ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+{{- if eq ( include "cert-manager.api-version" . | trim ) "certmanager.k8s.io/v1alpha1" }}
   acme:
     config:
       - http01:
@@ -28,7 +28,7 @@ spec:
 {{- end }}
 ---
 {{- range $index, $prefix := .Values.domainPrefixes }}
-{{- include "cert-manager.api-version" $ }}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-p{{ $index }}
@@ -44,7 +44,7 @@ spec:
   issuerRef:
     name: {{ $context_ssl.issuer }}
     kind: ClusterIssuer
-{{- if not ( $.Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+{{- if eq ( include "cert-manager.api-version" $ | trim ) "certmanager.k8s.io/v1alpha1" }}
   acme:
     config:
       - http01:
@@ -56,7 +56,7 @@ spec:
 {{- end }}
 
 {{- else if eq $context_ssl.issuer "selfsigned" }}
-{{- include "cert-manager.api-version" . }}
+apiVersion: {{ include "cert-manager.api-version" . | trim }}
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-crt
@@ -96,7 +96,7 @@ data:
 {{- if $domain.ssl }}
 {{- if $domain.ssl.enabled }}
 {{- if has $domain.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-{{- include "cert-manager.api-version" $ }}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-{{ $index }}
@@ -112,7 +112,7 @@ spec:
   issuerRef:
     name: {{ $domain.ssl.issuer }}
     kind: ClusterIssuer
-{{- if not ( $.Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+{{- if eq ( include "cert-manager.api-version" $ | trim ) "certmanager.k8s.io/v1alpha1" }}
   acme:
     config:
       - http01:
@@ -123,7 +123,7 @@ spec:
 ---
 
 {{- else if eq $domain.ssl.issuer "selfsigned" }}
-{{- include "cert-manager.api-version" $ }}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-{{ $index }}

--- a/charts/frontend/templates/ingress.yaml
+++ b/charts/frontend/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- $ingress := .Values.ingress.default }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "ingress.api-version" . | trim }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-nginx
@@ -63,16 +63,30 @@ spec:
       paths:
       - path: /
         backend:
+          {{- if eq ( include "ingress.api-version" . | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ .Release.Name }}-nginx
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ .Release.Name }}-nginx
           servicePort: 80
+          {{- end }}
 {{- range $index, $prefix := .Values.domainPrefixes }}
   - host: {{ $prefix }}.{{ template "frontend.domain" $ }}
     http:
       paths:
       - path: /
         backend:
+          {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ $.Release.Name }}-nginx
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ $.Release.Name }}-nginx
           servicePort: 80
+          {{- end }}
 {{- end }}
 ---
 # Ingresses for exposeDomains 
@@ -91,7 +105,7 @@ spec:
 {{- end }}
 
 {{- if $ingress_in_use }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "ingress.api-version" $ | trim }}
 kind: Ingress
 metadata:
   name: {{ $.Release.Name }}-nginx-{{ $ingress_index }}
@@ -158,8 +172,15 @@ spec:
       paths:
       - path: {{ if eq $ingress.type "gce" }}/*{{ else }}/{{ end }}
         backend:
+          {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ $.Release.Name }}-nginx
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ $.Release.Name }}-nginx
           servicePort: 80
+          {{- end }}
   {{- end }}
   {{- end }}
 ---

--- a/charts/frontend/templates/ingress.yaml
+++ b/charts/frontend/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- if $ingress.tls }}
-    {{- if ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+    {{- if eq ( include "cert-manager.api-version" . | trim ) "cert-manager.io/v1" }}
     acme.cert-manager.io/http01-edit-in-place: "true"
     {{- else }}
     certmanager.k8s.io/acme-http01-edit-in-place: "true"
@@ -98,7 +98,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- if $ingress.tls }}
-    {{- if ( $.Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+    {{- if eq ( include "cert-manager.api-version" $ | trim ) "cert-manager.io/v1" }}
     acme.cert-manager.io/http01-edit-in-place: "true"
     {{- else }}
     certmanager.k8s.io/acme-http01-edit-in-place: "true"

--- a/charts/frontend/tests/ingress_test.yaml
+++ b/charts/frontend/tests/ingress_test.yaml
@@ -36,12 +36,49 @@ tests:
           path: spec.rules[0].host
           value: 'foo.namespace.baz'
 
-  - it: directs traefik requests to nginx service by default
+  - it: directs traefik requests to nginx service by default (cm 0.8)
     template: ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 17
+      apiVersions:
+        - certmanager.k8s.io/v1alpha1
     asserts:
       - equal:
           path: spec.rules[0].http.paths[0].backend.serviceName
           value: 'RELEASE-NAME-nginx'
+
+  - it: directs traefik requests to nginx service by default (cm 1.4+)
+    template: ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+      apiVersions:
+        - cert-manager.io/v1
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: 'RELEASE-NAME-nginx'
+  
+  - it: uses correct ingress api version (1.17)
+    template: ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 17
+    asserts:
+      - equal:
+          path: apiVersion
+          value: 'networking.k8s.io/v1beta1'
+
+  - it: uses correct ingress api version (1.18+)
+    template: ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+    asserts:
+      - equal:
+          path: apiVersion
+          value: 'networking.k8s.io/v1'
 
   - it: shortens long project names
     template: ingress.yaml


### PR DESCRIPTION
- Unifies certificate apiVersion conditionals 
- Uses Ingress API v1 when kubernetes version is above 1.18
- Adjusted chart unittests