### PR TITLE
SLT-682: Remove duplicate apiVersion key in Chart.yaml

### DIFF
--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -1,7 +1,6 @@
-apiVersion: v1
+apiVersion: v2
 name: frontend
 version: 0.2.51
-apiVersion: v2
 dependencies:
 - name: mariadb
   version: 7.10.x


### PR DESCRIPTION
As far as I can tell from the outside, the duplicate apiVersion key originated in this PR to charts:
https://github.com/wunderio/charts/pull/88