### PR TITLE
Allow security header customization

### DIFF
--- a/charts/frontend/templates/_helpers.tpl
+++ b/charts/frontend/templates/_helpers.tpl
@@ -20,11 +20,11 @@ release: {{ .Release.Name }}
 {{- define "frontend.security_headers" }}
   ## https://www.owasp.org/index.php/List_of_useful_HTTP_headers.
   {{- range $header, $value := .Values.nginx.security_headers }}
-  add_header    {{ $header }} {{ $value }};
+  add_header                  {{ $header }} {{ $value }};
   {{- end }}
-  add_header    Strict-Transport-Security "max-age=31536000; {{ .Values.nginx.hsts_include_subdomains }} preload" always;
+  add_header                  Strict-Transport-Security "max-age=31536000; {{ .Values.nginx.hsts_include_subdomains }} preload" always;
   {{- if .Values.nginx.content_security_policy }}
-  add_header    Content-Security-Policy "{{ .Values.nginx.content_security_policy }}" always;
+  add_header                  Content-Security-Policy "{{ .Values.nginx.content_security_policy }}" always;
   {{- end }}
 {{- end }}
 

--- a/charts/frontend/templates/_helpers.tpl
+++ b/charts/frontend/templates/_helpers.tpl
@@ -19,14 +19,13 @@ release: {{ .Release.Name }}
 
 {{- define "frontend.security_headers" }}
   ## https://www.owasp.org/index.php/List_of_useful_HTTP_headers.
-  add_header    X-Frame-Options SAMEORIGIN;
-  add_header    X-Content-Type-Options nosniff;
+  {{- range $header, $value := .Values.nginx.security_headers }}
+  add_header    {{ $header }} {{ $value }};
+  {{- end }}
   add_header    Strict-Transport-Security "max-age=31536000; {{ .Values.nginx.hsts_include_subdomains }} preload" always;
   {{- if .Values.nginx.content_security_policy }}
   add_header    Content-Security-Policy "{{ .Values.nginx.content_security_policy }}" always;
   {{- end }}
-  add_header    X-XSS-Protection "1; mode=block";
-  add_header    Referrer-Policy "no-referrer, strict-origin-when-cross-origin" always;
 {{- end }}
 
 {{- define "frontend.tolerations" -}}

--- a/charts/frontend/templates/configmap.yaml
+++ b/charts/frontend/templates/configmap.yaml
@@ -68,7 +68,7 @@ data:
         gzip_proxied                any;       
         gzip_disable                msie6;                                                                                                                 
                                                                                                                                                           
-        {{ include "frontend.security_headers" $ | indent 4 }}
+        {{ include "frontend.security_headers" $ | indent 6 }}
 
         map_hash_bucket_size 128;
 

--- a/charts/frontend/tests/configmap_test.yaml
+++ b/charts/frontend/tests/configmap_test.yaml
@@ -58,3 +58,39 @@ tests:
     - matchRegex:
         path: data.nginx_conf
         pattern: 'set_real_ip_from *2.2.2.2'
+
+  - it: tests nginx security headers
+    template: configmap.yaml
+    set:
+      nginx:
+        security_headers: 
+          foo: bar
+        content_security_policy: "baz"
+    asserts:
+    - matchRegex:
+        path: data.nginx_conf
+        pattern: 'add_header    X-Frame-Options SAMEORIGIN;'
+    - matchRegex:
+        path: data.nginx_conf
+        pattern: 'add_header    foo bar;'
+    - matchRegex:
+        path: data.nginx_conf
+        pattern: 'add_header    Content-Security-Policy "baz" always;'
+
+  - it: tests ability to set empty nginx security headers
+    template: configmap.yaml
+    set:
+      nginx:
+        security_headers: []
+        content_security_policy: ""
+    asserts:
+    - notMatchRegex:
+        path: data.nginx_conf
+        pattern: 'add_header    X-Frame-Options SAMEORIGIN;'
+    - notMatchRegex:
+        path: data.nginx_conf
+        pattern: 'add_header    header_foo value_bar;'
+    - notMatchRegex:
+        path: data.nginx_conf
+        pattern: 'add_header    Content-Security-Policy "baz" always;'
+

--- a/charts/frontend/tests/configmap_test.yaml
+++ b/charts/frontend/tests/configmap_test.yaml
@@ -69,13 +69,13 @@ tests:
     asserts:
     - matchRegex:
         path: data.nginx_conf
-        pattern: 'add_header    X-Frame-Options SAMEORIGIN;'
+        pattern: 'add_header                  X-XSS-Protection "1; mode=block";'
     - matchRegex:
         path: data.nginx_conf
-        pattern: 'add_header    foo bar;'
+        pattern: 'add_header                  foo bar;'
     - matchRegex:
         path: data.nginx_conf
-        pattern: 'add_header    Content-Security-Policy "baz" always;'
+        pattern: 'add_header                  Content-Security-Policy "baz" always;'
 
   - it: tests ability to set empty nginx security headers
     template: configmap.yaml
@@ -86,11 +86,11 @@ tests:
     asserts:
     - notMatchRegex:
         path: data.nginx_conf
-        pattern: 'add_header    X-Frame-Options SAMEORIGIN;'
+        pattern: 'add_header                  X-XSS-Protection "1; mode=block";'
     - notMatchRegex:
         path: data.nginx_conf
-        pattern: 'add_header    header_foo value_bar;'
+        pattern: 'add_header                  header_foo value_bar;'
     - notMatchRegex:
         path: data.nginx_conf
-        pattern: 'add_header    Content-Security-Policy "baz" always;'
+        pattern: 'add_header                  Content-Security-Policy "baz" always;'
 

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -144,6 +144,12 @@ nginx:
       password: demo
 
   # Security headers
+  security_headers:
+    X-Frame-Options: 'SAMEORIGIN'
+    X-Content-Type-Options: 'nosniff'
+    X-XSS-Protection: '"1; mode=block"'
+    Referrer-Policy: '"no-referrer, strict-origin-when-cross-origin" always'
+  
   # includeSubdomains should be used whenever possible, but before enabling it needs to be made sure there are no subdomains not using https:
   hsts_include_subdomains: ""
   #hsts_include_subdomains: " includeSubDomains;"


### PR DESCRIPTION
tip: remove security headers by setting `nginx.security_headers: ""`