### PR TITLE
Add INSTANA_AGENT_HOST env to node deployments when Instana is enabled

### DIFF
--- a/charts/frontend/README.md
+++ b/charts/frontend/README.md
@@ -22,3 +22,5 @@ Service containers have following environment variables:
       - DB_NAME: Database name. Set to "frontend" by default.
   - When MongoDB is enabled:
     - MONGODB_HOST: MongoDB server host.
+  - When Instana is enabled:
+    - INSTANA_AGENT_HOST: IP address of host where Instana agent is running.

--- a/charts/frontend/templates/_helpers.tpl
+++ b/charts/frontend/templates/_helpers.tpl
@@ -138,6 +138,13 @@ rsync -az /values_mounts/ /backups/current/
 - name: NO_PROXY
   value: .svc.cluster.local,{{ .Release.Name }}-mongodb,{{ .Release.Name }}-es{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
 {{- end }}
+{{ if .Values.instana.enabled -}}
+# Instana
+- name: INSTANA_AGENT_HOST
+  valueFrom:
+    fieldRef:
+      fieldPath: status.hostIP
+{{- end }}
 {{- end }}
 
 {{- define "cert-manager.api-version" }}

--- a/charts/frontend/values.schema.json
+++ b/charts/frontend/values.schema.json
@@ -59,6 +59,12 @@
         "enabled": { "type": "boolean" }
       }
     },
+    "instana": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
     "silta-release": {
       "type": "object"
     }

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -411,3 +411,9 @@ rabbitmq:
   # Use a low default to prevent unnecessary storage use.
   persistence:
     size: 1Gi
+
+# Add following lines to your node.Dockerfile when enabling instana monitoring
+#   RUN npm install -g @instana/collector
+#   ENV NODE_OPTIONS="--require /usr/local/lib/node_modules/@instana/collector/src/immediate"
+instana:
+  enabled: false


### PR DESCRIPTION
To enable Instana NodeJS monitoring:

### Add `@instana/collector` to your node process
```Dockerfile
FROM wunderio/silta-node:v0.1

COPY . /app

# Install APM (Instana collector for NodeJS)
# Read more: https://www.ibm.com/docs/de/obi/current?topic=nodejs-collector-installation#global-installation
RUN npm install -g @instana/collector
ENV NODE_OPTIONS="--require /usr/local/lib/node_modules/@instana/collector/src/immediate"

WORKDIR /app

ENV PORT 3000

CMD ["node", "server.js"]
```

### Enable instana in `silta.yml`

```
instana:
  enabled: true
```

### Tests

I didn't find a way to assert if `INSTANA_AGENT_HOST` environment variable is set. I also didn't get snapshots generated to try out snapshot testing.