### PR TITLE
Silta container base image migration to Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,13 @@ orbs:
 executors:
   node12:
     docker:
-      - image: eu.gcr.io/silta-images/cicd:circleci-php7.3-node12-composer1-v0.1
+      - image: wunderio/silta-cicd:circleci-php7.3-node12-composer1-v0.1
   node14:
     docker:
-      - image: eu.gcr.io/silta-images/cicd:circleci-php8.0-node14-composer2-v0.1
+      - image: wunderio/silta-cicd:circleci-php8.0-node14-composer2-v0.1
   node16:
     docker:
-      - image: eu.gcr.io/silta-images/cicd:circleci-php8.0-node16-composer2-v0.1
+      - image: wunderio/silta-cicd:circleci-php8.0-node16-composer2-v0.1
 
 jobs:
   validate:

--- a/charts/frontend/templates/backup-cron.yaml
+++ b/charts/frontend/templates/backup-cron.yaml
@@ -21,7 +21,7 @@ spec:
           enableServiceLinks: false
           initContainers:
             - name: backup-linking
-              image: eu.gcr.io/silta-images/rsync:latest
+              image: wunderio/silta-rsync:latest
               command: ["/bin/bash", "-c"]
               args:
                 - |
@@ -39,7 +39,7 @@ spec:
                   name: shared-data
           containers:
           - name: backup
-            image: eu.gcr.io/silta-images/rsync:latest
+            image: wunderio/silta-rsync:latest
             volumeMounts:
               {{- range $index, $mount := $.Values.mounts -}}
               {{- if eq $mount.enabled true }}

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -96,7 +96,7 @@ domainPrefixes: []
 
 # These variables are build-specific and should be passed via the --set parameter.
 nginx:
-  image: 'wunderio/drupal-nginx:v0.1'
+  image: 'wunderio/silta-nginx:v0.1'
 
   replicas: 1
 

--- a/silta/hello.Dockerfile
+++ b/silta/hello.Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/silta-images/node:16-alpine-v0.1
+FROM wunderio/silta-node:16-alpine-v0.1
 
 COPY ./hello /app
 

--- a/silta/world.Dockerfile
+++ b/silta/world.Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/silta-images/node:16-alpine-v0.1
+FROM wunderio/silta-node:16-alpine-v0.1
 
 COPY ./world /app
 


### PR DESCRIPTION
Silta docker container images are being migrated from [Google Container Registry](https://eu.gcr.io/silta-images/) to [Docker Hub](https://hub.docker.com/u/wunderio).
This PR changes base image location to the new image registry and adjusts some image names.

Please review adjusted image paths and make sure this PR only changes relevant configuration files.

This pull request was created with https://github.com/wunderio/internal-mass-updater.