### PR TITLE
SLT-779: Single subdomain and custom ssl certificate for domain prefixes.

### DIFF
--- a/charts/frontend/templates/_domains.tpl
+++ b/charts/frontend/templates/_domains.tpl
@@ -1,4 +1,11 @@
 
+{{- define "frontend.domainSeperator" -}}
+{{- if .Values.singleSubdomain -}}
+-
+{{- else -}}
+.
+{{- end -}}
+{{- end -}}
 
 {{- define "frontend.domain" -}}
 {{- $projectName := regexReplaceAll "[^[:alnum:]]" (.Values.projectName | default .Release.Namespace) "-"  | trimSuffix "-" | lower }}
@@ -10,11 +17,11 @@
 {{- if .prefix -}}
 {{- $maxEnvironmentNameLength := int (sub 61 (add (len .Values.clusterDomain) (len $projectName) (len .prefix))) }}
 {{- $environmentName := (ge (len $environmentName) $maxEnvironmentNameLength) | ternary (print ($environmentName | trunc (int (sub $maxEnvironmentNameLength 3))) $environmentNameHash) $environmentName -}}
-{{ .prefix }}.{{ $environmentName }}.{{ $projectName }}.{{ .Values.clusterDomain }}
+{{ .prefix }}{{ include "frontend.domainSeperator" . }}{{ $environmentName }}{{ include "frontend.domainSeperator" . }}{{ $projectName }}.{{ .Values.clusterDomain }}
 {{- else -}}
 {{- $maxEnvironmentNameLength := int (sub 62 (add (len .Values.clusterDomain) (len $projectName))) }}
 {{- $environmentName := (ge (len $environmentName) $maxEnvironmentNameLength) | ternary (print ($environmentName | trunc (int (sub $maxEnvironmentNameLength 3))) $environmentNameHash) $environmentName -}}
-{{ $environmentName }}.{{ $projectName }}.{{ .Values.clusterDomain }}
+{{ $environmentName }}{{ include "frontend.domainSeperator" . }}{{ $projectName }}.{{ .Values.clusterDomain }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/frontend/templates/certificate.yaml
+++ b/charts/frontend/templates/certificate.yaml
@@ -74,6 +74,26 @@ spec:
     name: {{ $context_ssl.issuer }}
     kind: ClusterIssuer
 ---
+{{- range $index, $prefix := .Values.domainPrefixes }}
+{{- $params := dict "prefix" $prefix  -}}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
+kind: Certificate
+metadata:
+  name: {{ $.Release.Name }}-crt-p{{ $index }}
+  labels:
+    {{- include "frontend.release_labels" $ | nindent 4 }}
+spec:
+  secretName: {{ $.Release.Name }}-tls-p{{ $index }}
+  duration: 2160h
+  renewBefore: 150h
+  commonName: {{ include "frontend.domain" (merge $params $ ) }}
+  dnsNames:
+    - '{{ include "frontend.domain" (merge $params $ ) }}'
+  issuerRef:
+    name: {{ $context_ssl.issuer }}
+    kind: ClusterIssuer
+---
+{{- end }}
 
 {{- else if eq $context_ssl.issuer "custom" }}
 apiVersion: v1
@@ -88,6 +108,20 @@ data:
   tls.crt: {{ $context_ssl.crt | b64enc }}
   tls.key: {{ $context_ssl.key | b64enc }}
 ---
+{{- range $index, $prefix := .Values.domainPrefixes }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $.Release.Name }}-tls-p{{ $index }}-custom
+  labels:
+    {{- include "frontend.release_labels" $ | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.ca: {{ $context_ssl.ca | b64enc }}
+  tls.crt: {{ $context_ssl.crt | b64enc }}
+  tls.key: {{ $context_ssl.key | b64enc }}
+---
+{{- end }}
 {{- end }}
 
 # Certificates for exposeDomains 

--- a/charts/frontend/values.schema.json
+++ b/charts/frontend/values.schema.json
@@ -11,6 +11,7 @@
     "exposeDomains": { "type": "object", "items": { "type": "object"}},
     "exposeDomainsDefaults": { "type": "object"},
     "domainPrefixes": { "type": "array", "items": { "type": "string"}},
+    "singleSubdomain": { "type": "boolean"},
     "ssl": { "type": "object" },
     "backendConfig": { "type": ["array","object"], "items": { "type": "object"}},
     "ingress": { "type": "object" },

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -94,6 +94,10 @@ backendConfig:
 # domainPrefixes: ['en', 'fi']
 domainPrefixes: []
 
+# Domains by default are created following pattern branch.repository.cluster
+# By enabling single subdomain it will be converted to branch-repository.cluster
+singleSubdomain: false
+
 # These variables are build-specific and should be passed via the --set parameter.
 nginx:
   image: 'wunderio/drupal-nginx:v0.1'


### PR DESCRIPTION
**Allows setting single subdomain and fixes custom ssl certificates for sites with domain prefixes.**

Features:

- Adds "singleSubdomain" flag to set "-" as a prefix, branch and repo separator.
- Set flag to "false" by default to not break any existing implementations
- Creates separate secrets for custom ssl certs.