### PR TITLE
Trigger subchart update; disable enableServiceLinks by default

### DIFF
--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 0.2.74
+version: 0.2.75
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -358,6 +358,7 @@ mariadb:
               operator: NotIn
               values:
               - static-ip
+  enableServiceLinks: false
 
 elasticsearch:
   enabled: false


### PR DESCRIPTION
Use updated mariadb subchart fork, disable enableServiceLinks by default
