### PR TITLE
Do not add backendConfig annotation to service when it's unset

### DIFF
--- a/charts/frontend/templates/service.yaml
+++ b/charts/frontend/templates/service.yaml
@@ -7,8 +7,8 @@ metadata:
   annotations:
     auto-downscale/down: "false"
     {{- if .Values.cluster }}
-    {{- if eq .Values.cluster.type "gke" }}
-    cloud.google.com/backend-config: '{"ports": {"8080":"{{ .Release.Name }}-nginx"}}'
+    {{- if and (eq .Values.cluster.type "gke") (.Values.backendConfig) }}
+    cloud.google.com/backend-config: '{"default":"{{ .Release.Name }}-nginx"}'
     {{- end }}
     {{- if .Values.cluster.vpcNative }}
     cloud.google.com/neg: '{"ingress": true}'
@@ -20,7 +20,9 @@ spec:
   # We explicitly unset this, in case the application is currently downscaled.
   externalName: null
   ports:
-    - port: 80
+    - name: web
+      port: 80
+      protocol: TCP
       targetPort: 8080
   selector:
     {{ include "frontend.release_labels" . | indent 4 }}


### PR DESCRIPTION
- Does not add backendConfig annotation to service when backendConfig is unset
- Changes backendconfig rule from specific port to default

