### PR TITLE
SLT-800: Improve Cron logging

### DIFF
--- a/charts/frontend/templates/services-cron.yaml
+++ b/charts/frontend/templates/services-cron.yaml
@@ -68,7 +68,7 @@ spec:
 
                 # The execution of the actual cron command.
                 # For backward compatibility reasons send the output to stdout as well (tee).
-                /usr/bin/time -f '"elapsed_time_s":%e,"peak_mem_kb":%M' -o "${stats}" "${script}" 2>&1 \
+                /usr/bin/time -f '"duration_s":%e,"peak_mem_kb":%M' -o "${stats}" "${script}" 2>&1 \
                 | tee "${output}"
 
                 # For backward compatibility.
@@ -85,7 +85,7 @@ spec:
                 # the output file contains also a warning,
                 # which is not JSON.
                 # Get rid of this.
-                stats="$(grep -E '"elapsed_time_s".*"peak_mem_kb"' ${stats})"
+                stats="$(grep -E '"duration_s".*"peak_mem_kb"' ${stats})"
 
                 cron_name="{{ $serviceName }}:{{ $jobName }}"
 

--- a/charts/frontend/templates/services-cron.yaml
+++ b/charts/frontend/templates/services-cron.yaml
@@ -87,8 +87,7 @@ spec:
                 # Get rid of this.
                 stats="$(grep -E '"elapsed_time_s".*"peak_mem_kb"' ${stats})"
 
-                echo "Debug: serviceName={{ $serviceName }} service.cron={{ $service.cron }} jobName={{ $jobName }}"
-                cron_name="{{ $serviceName }}"
+                cron_name="{{ $serviceName }}:{{ $jobName }}"
 
                 # Assemble the JSON output.
                 cat << JSON

--- a/charts/frontend/templates/services-cron.yaml
+++ b/charts/frontend/templates/services-cron.yaml
@@ -43,13 +43,60 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
-            command: ["/bin/sh", "-c"]
+            command: ["/bin/bash", "-c"]
             args:
               - |
-                 set -ex
-                 echo "starting cron run"
-                 {{ $job.command | nindent 18 }}
-                 echo "cron run completed"
+                # We need to save the executable command(s) into a file,
+                # because the 'time' can exeute only command-files,
+                # not the shell constructs.
+                script="/tmp/cron.$$"
+                cat << CMD > "${script}"
+                #!/bin/bash
+                set -x
+                {{ $job.command | nindent 16 }}
+                CMD
+                chmod 755 "${script}"
+
+                # Try to make the tmp files more unique.
+                # $$ = pid of current running shell.
+                stats="/tmp/stats.$$"
+                output="/tmp/output.$$"
+                output_json="/tmp/output_json.$$"
+
+                # For backwards compatibility.
+                echo "starting cron run"
+
+                # The execution of the actual cron command.
+                # For backwards compatibility reasons sent the output to stdout as well (tee).
+                /usr/bin/time -f '"elapsed_time_s":%e,"peak_mem_kb":%M' -o "${stats}" "${script}" 2>&1 \
+                | tee "${output}"
+
+                # For backwards compatibility.
+                echo "cron run completed"
+
+                # It's tricky to get exit code of a random command from a pipeline.
+                # It is highly shell-dependent.
+                exit_code="${PIPESTATUS[0]}"
+
+                # Convert the command output to json.
+                node -e 'const fs = require("fs"); console.log(JSON.stringify(fs.readFileSync(0, "utf-8")));' < "${output}" > "${output_json}"
+
+                # If the error code is non-zero,
+                # the output file contains also a warning,
+                # which is not json.
+                # Get rid of this.
+                stats="$(grep -E '"elapsed_time_s".*"peak_mem_kb"' ${stats})"
+
+                echo "Debug: serviceName={{ $serviceName }} service.cron={{ $service.cron }} jobName={{ $jobName }}"
+                cron_name="{{ $serviceName }}"
+
+                # Assemble the JSON output.
+                cat << JSON
+                {"cron_name":"${cron_name}",${stats},"exit_code":${exit_code},"output":$(cat "${output_json}")}
+                JSON
+
+                # Use the exit code of the actual cron command.
+                exit "$exit_code"
             resources:
               {{- if $job.resources }}
               {{- if $service.resources }}

--- a/charts/frontend/templates/services-cron.yaml
+++ b/charts/frontend/templates/services-cron.yaml
@@ -47,7 +47,7 @@ spec:
             args:
               - |
                 # We need to save the executable command(s) into a file,
-                # because the 'time' can exeute only command-files,
+                # because the 'time' can execute only command files,
                 # not the shell constructs.
                 script="/tmp/cron.$$"
                 cat << CMD > "${script}"
@@ -57,33 +57,33 @@ spec:
                 CMD
                 chmod 755 "${script}"
 
-                # Try to make the tmp files more unique.
-                # $$ = pid of current running shell.
+                # Try to make the temporary files more unique.
+                # $$ = PID of the current running shell.
                 stats="/tmp/stats.$$"
                 output="/tmp/output.$$"
                 output_json="/tmp/output_json.$$"
 
-                # For backwards compatibility.
+                # For backward compatibility.
                 echo "starting cron run"
 
                 # The execution of the actual cron command.
-                # For backwards compatibility reasons sent the output to stdout as well (tee).
+                # For backward compatibility reasons send the output to stdout as well (tee).
                 /usr/bin/time -f '"elapsed_time_s":%e,"peak_mem_kb":%M' -o "${stats}" "${script}" 2>&1 \
                 | tee "${output}"
 
-                # For backwards compatibility.
+                # For backward compatibility.
                 echo "cron run completed"
 
-                # It's tricky to get exit code of a random command from a pipeline.
+                # It's tricky to get the exit code of a random command from a pipeline.
                 # It is highly shell-dependent.
                 exit_code="${PIPESTATUS[0]}"
 
-                # Convert the command output to json.
+                # Convert the command output to JSON.
                 node -e 'const fs = require("fs"); console.log(JSON.stringify(fs.readFileSync(0, "utf-8")));' < "${output}" > "${output_json}"
 
                 # If the error code is non-zero,
                 # the output file contains also a warning,
-                # which is not json.
+                # which is not JSON.
                 # Get rid of this.
                 stats="$(grep -E '"elapsed_time_s".*"peak_mem_kb"' ${stats})"
 

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -37,7 +37,7 @@ services:
     cron:
       world-cli:
         command: echo $(date) > /app/files/lastupdate.txt
-        schedule: "~ * * * *"
+        schedule: "* * * * *"
     backup:
       command: |
         echo "made in world container" >> /backups/current/world_file

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -37,7 +37,7 @@ services:
     cron:
       world-cli:
         command: echo $(date) > /app/files/lastupdate.txt
-        schedule: "* * * * *"
+        schedule: "~ * * * *"
     backup:
       command: |
         echo "made in world container" >> /backups/current/world_file


### PR DESCRIPTION
- Generate statistics at the end of the execution
- Generate stats as JSON
- Capture job output, and export also in the JSON

The logs will look like this:

```JSON
{
  "cron_name":"world:world-cli",
  "elapsed_time_s":0.02,
  "peak_mem_kb":7360,
  "exit_code":0,
  "output":"..."
}
```