### PR TITLE
ingress-nginx support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,8 +97,9 @@ workflows:
               ignore:
                 - production
                 - /feature\/test\/.*/
+                - /feature\/test-cluster\/.*/
                 - /feature\/aws\/.*/
-                - feature/cert-manager-upgrade
+                - /feature\/cert-manager-upgrade
 
       - silta/frontend-build-deploy:
           # Extend the build-deploy configuration for the test cluster deployments
@@ -129,8 +130,9 @@ workflows:
           filters:
             branches:
               only: 
-                - feature\/test\/.*/
-                - feature/cert-manager-upgrade
+                - /feature\/test\/.*/
+                - /feature\/test-cluster\/.*/
+                - /feature\/cert-manager-upgrade
 
       - silta/frontend-build-deploy:
           # Extend the build-deploy configuration for the aws cluster deployments
@@ -210,8 +212,9 @@ workflows:
               ignore:
                 - production
                 - /feature\/test\/.*/
+                - /feature\/test-cluster\/.*/
                 - /feature\/aws\/.*/
-                - feature/cert-manager-upgrade
+                - /feature\/cert-manager-upgrade
 
       - silta/frontend-build-deploy:
           # Extend the build-deploy configuration for the test cluster deployments

--- a/charts/frontend/templates/ingress.yaml
+++ b/charts/frontend/templates/ingress.yaml
@@ -38,12 +38,14 @@ metadata:
     ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
     {{- if eq $ingress.type "traefik" }}
     nginx.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    nginx.org/redirect-to-https: {{ $redirect_https | quote }}
     {{- end }}
     {{- if eq $ingress.type "azure/application-gateway" }}
     appgw.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
     {{- end }}
     {{- if eq $ingress.type "nginx" }}
     nginx.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    nginx.org/redirect-to-https: {{ $redirect_https | quote }}
     {{- end }}
     {{- end }}
     
@@ -188,12 +190,14 @@ metadata:
     ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
     {{- if eq $ingress.type "traefik" }}
     nginx.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    nginx.org/redirect-to-https: {{ $redirect_https | quote }}
     {{- end }}
     {{- if eq $ingress.type "azure/application-gateway" }}
     appgw.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
     {{- end }}
     {{- if eq $ingress.type "nginx" }}
     nginx.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    nginx.org/redirect-to-https: {{ $redirect_https | quote }}
     {{- end }}
     {{- end }}
     

--- a/charts/frontend/templates/ingress.yaml
+++ b/charts/frontend/templates/ingress.yaml
@@ -36,8 +36,14 @@ metadata:
     {{- end }}
     {{- if $redirect_https }}
     ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    {{- if eq $ingress.type "traefik" }}
+    nginx.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    {{- end }}
     {{- if eq $ingress.type "azure/application-gateway" }}
     appgw.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    {{- end }}
+    {{- if eq $ingress.type "nginx" }}
+    nginx.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
     {{- end }}
     {{- end }}
     
@@ -62,6 +68,7 @@ metadata:
     {{- end }}
 
     {{- if (index .Values "silta-release").downscaler.enabled }}
+    auto-downscale/down: "false"
     auto-downscale/last-update: {{ dateInZone "2006-01-02T15:04:05.999Z" (now) "UTC" }}
     auto-downscale/label-selector: "release={{ .Release.Name }}"
     auto-downscale/services: {{ .Release.Name }}-nginx
@@ -179,8 +186,14 @@ metadata:
     {{- end }}
     {{- if $redirect_https }}
     ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    {{- if eq $ingress.type "traefik" }}
+    nginx.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    {{- end }}
     {{- if eq $ingress.type "azure/application-gateway" }}
     appgw.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    {{- end }}
+    {{- if eq $ingress.type "nginx" }}
+    nginx.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
     {{- end }}
     {{- end }}
     
@@ -202,6 +215,13 @@ metadata:
 
     {{- if $ingress.extraAnnotations }}
     {{- $ingress.extraAnnotations | toYaml | nindent 4 }}
+    {{- end }}
+
+    {{- if (index $.Values "silta-release").downscaler.enabled }}
+    auto-downscale/down: "false"
+    auto-downscale/last-update: {{ dateInZone "2006-01-02T15:04:05.999Z" (now) "UTC" }}
+    auto-downscale/label-selector: "release={{ $.Release.Name }}"
+    auto-downscale/services: {{ $.Release.Name }}-nginx
     {{- end }}
   labels:
     {{ include "frontend.release_labels" $ | indent 4 }}

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -70,6 +70,10 @@ ingress:
             period: 5s
             average: 150
             burst: 200
+      nginx.ingress.kubernetes.io/limit-rps: "32"
+      nginx.ingress.kubernetes.io/limit-rpm: "300"
+      nginx.ingress.kubernetes.io/limit-burst-multiplier: "3"
+      nginx.ingress.kubernetes.io/limit-connections: "20"
   gce:
     type: gce
     # The name of the reserved static IP address.


### PR DESCRIPTION
- Adds nginx ingress annotations to default configuration (allows switching out traefik ingress while keeping the same name):
  - http->https redirect abstraction
  - rate limits
- Adds downscaler annotation to `exposeDomains`, allowing wakeup via `exposeDomain` entries