### PR TITLE
Fastly Signal Sciences WAF support

### DIFF
--- a/charts/frontend/templates/configmap.yaml
+++ b/charts/frontend/templates/configmap.yaml
@@ -12,6 +12,9 @@ data:
   {{- end }}
 
   nginx_conf: |
+
+    include modules/*.conf;
+
     # user                            nginx;
     worker_processes                auto;
     worker_rlimit_nofile            10240;

--- a/charts/frontend/templates/configmap.yaml
+++ b/charts/frontend/templates/configmap.yaml
@@ -5,20 +5,31 @@ metadata:
   labels:
     {{ include "frontend.release_labels" . | indent 4 }}
 data:
+  {{- if .Values.signalsciences.enabled }}
+  nginx_signalsciences_conf: |
+    load_module /etc/nginx/modules/ngx_http_sigsci_module.so;
+    load_module /etc/nginx/modules/ndk_http_module.so;
+  {{- end }}
+
   nginx_conf: |
-    # user                            nginx;                                                 
+    # user                            nginx;
     worker_processes                auto;
     worker_rlimit_nofile            10240;
 
-    error_log                       /proc/self/fd/2 {{ .Values.nginx.loglevel }};                                 
-                                                                                          
-    events {                                                                               
-        worker_connections          10240;                                                  
-        multi_accept                on;                                                    
-    }                                                                                      
-                                                                                          
+    error_log                       /proc/self/fd/2 {{ .Values.nginx.loglevel }};
+
+    events {
+        worker_connections          10240;
+        multi_accept                on;
+    }
+
     http {
-        
+
+        {{- if .Values.signalsciences.enabled }}
+        # Signal sciences agent socket
+        sigsci_agent_host unix:/sigsci/tmp/sigsci.sock;
+        {{- end }}
+
         # List of upstream proxies we trust to set X-Forwarded-For correctly.
         {{- if kindIs "string" .Values.nginx.realipfrom }}
         set_real_ip_from            {{ .Values.nginx.realipfrom }};
@@ -31,43 +42,43 @@ data:
 
         real_ip_header              {{ .Values.nginx.real_ip_header }};
 
-        include                     /etc/nginx/mime.types;                                 
-        default_type                application/octet-stream;                              
-                                                                                          
+        include                     /etc/nginx/mime.types;
+        default_type                application/octet-stream;
+
         log_format  main            '$remote_addr - $remote_user [$time_local] "$request" '
                                     '$status $body_bytes_sent "$http_referer" '
                                     '"$http_user_agent" "$http_x_forwarded_for"';
-                                                            
-                                                                                                              
+
+
         access_log                  /proc/self/fd/1 main;
-                                              
-        send_timeout                60s;       
-        sendfile                    on;        
-        client_body_timeout         60s;       
-        client_header_timeout       60s;                                                                                                                   
-        client_max_body_size        32m;                                                                                                                   
-        client_body_buffer_size     16k;                                                                                                                   
-        client_header_buffer_size   4k;                                                                                                                    
-        large_client_header_buffers 8 16K;                                                                                                                 
-        keepalive_timeout           75s;                                                                                                                   
-        keepalive_requests          100;                                                                                                                   
-        reset_timedout_connection   off;                                                                                                                   
-        tcp_nodelay                 on;                                                                                                                    
-        tcp_nopush                  on;                                                                                                                    
-        server_tokens               off;                                                                                                                   
-                                                                                                                                                          
-        ## upload_progress             uploads 1m;          
-                                              
-        gzip                        on;                      
-        gzip_buffers                16 8k;     
-        gzip_comp_level             1;         
-        gzip_http_version           1.1;       
-        gzip_min_length             20;        
+
+        send_timeout                60s;
+        sendfile                    on;
+        client_body_timeout         60s;
+        client_header_timeout       60s;
+        client_max_body_size        32m;
+        client_body_buffer_size     16k;
+        client_header_buffer_size   4k;
+        large_client_header_buffers 8 16K;
+        keepalive_timeout           75s;
+        keepalive_requests          100;
+        reset_timedout_connection   off;
+        tcp_nodelay                 on;
+        tcp_nopush                  on;
+        server_tokens               off;
+
+        ## upload_progress             uploads 1m;
+
+        gzip                        on;
+        gzip_buffers                16 8k;
+        gzip_comp_level             1;
+        gzip_http_version           1.1;
+        gzip_min_length             20;
         gzip_types                  text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascrip
-        gzip_vary                   on;                                                                                                                    
-        gzip_proxied                any;       
-        gzip_disable                msie6;                                                                                                                 
-                                                                                                                                                          
+        gzip_vary                   on;
+        gzip_proxied                any;
+        gzip_disable                msie6;
+
         {{ include "frontend.security_headers" $ | indent 6 }}
 
         map_hash_bucket_size 128;
@@ -82,21 +93,21 @@ data:
         }
         add_header                  X-Robots-Tag $x_robots_tag_header;
 
-        map $uri $no_slash_uri {                                                                                                                           
-            ~^/(?<no_slash>.*)$ $no_slash;                                                                                                                 
+        map $uri $no_slash_uri {
+            ~^/(?<no_slash>.*)$ $no_slash;
         }
 
         # List health checks that need to return status 200 here
-        map $http_user_agent $hc_ua { default 0; 'GoogleHC/1.0' 1; }                                                             
-                                                                                                                                                          
-        include conf.d/*.conf;                                                                                                                             
-    }     
+        map $http_user_agent $hc_ua { default 0; 'GoogleHC/1.0' 1; }
+
+        include conf.d/*.conf;
+    }
 
   frontend_conf: |
-    map $http_x_forwarded_proto $fastcgi_https {                                                        
-        default $https;                                            
-        http '';                          
-        https on;                          
+    map $http_x_forwarded_proto $fastcgi_https {
+        default $https;
+        http '';
+        https on;
     }
 
     {{- if .Values.nginx.redirects }}
@@ -118,11 +129,11 @@ data:
     }
     {{- end }}
 
-    server {                               
+    server {
         server_name frontend;
         listen 8080;
 
-        # Loadbalancer health checks need to be fed with http 200 
+        # Loadbalancer health checks need to be fed with http 200
         if ($hc_ua) { return 200; }
 
         {{- if .Values.nginx.redirects }}
@@ -133,11 +144,11 @@ data:
         if ($redirect_uri_local) {
     	    return 301 $redirect_uri_local;
         }
-        {{- end }}          
-                                        
+        {{- end }}
+
         root /app/web;
         index index.html;
-                                                                              
+
         include fastcgi.conf;
 
         # Custom configuration gets included here
@@ -146,7 +157,7 @@ data:
         {{- range $index, $service := .Values.services }}
         {{ if $service.exposedRoute }}
         location {{ $service.exposedRoute }} {
-        
+
           {{ if $.Values.nginx.extra_conditions }}
           {{ $.Values.nginx.extra_conditions | nindent 10 }}
           {{- end}}
@@ -157,7 +168,7 @@ data:
           {{- end }}
 
           {{ include "frontend.basicauth" $ | indent 6}}
-          
+
           location = {{ $service.exposedRoute }}/robots.txt {
             access_log off;
           }
@@ -204,11 +215,11 @@ data:
           add_header              Front-End-Https   on;
 
           {{ include "frontend.security_headers" $ | indent 6 }}
-    
+
           {{- range $header_name, $header_value := $.Values.nginx.extra_headers }}
           add_header {{ $header_name }} {{ $header_value }};
           {{- end }}
-        }    
+        }
         {{- end }}
         {{- end }}
     }

--- a/charts/frontend/templates/nginx.yaml
+++ b/charts/frontend/templates/nginx.yaml
@@ -38,6 +38,14 @@ spec:
           mountPath: /etc/nginx/conf.d/frontend.conf # mount nginx-conf configmap volume to /etc/nginx
           readOnly: true
           subPath: frontend_conf
+        {{- if .Values.signalsciences.enabled }}
+        - name: nginx-conf
+          mountPath: /etc/nginx/modules/nginx_signalsciences.conf
+          readOnly: true
+          subPath: nginx_signalsciences_conf
+        - name: sigsci-tmp
+          mountPath: /sigsci/tmp
+        {{- end }}
         {{- if .Values.nginx.extraConfig }}
         - name: config
           # provide empty configuration file in /etc/nginx/conf.d for users to populate
@@ -63,6 +71,36 @@ spec:
               command: ["/bin/sleep", "5"]
         resources:
           {{ .Values.nginx.resources | toYaml | nindent 10 }}
+
+      {{- if .Values.signalsciences.enabled }}
+      # Signal Services container
+      - name: sigsci
+        image: {{ .Values.signalsciences.image }}:{{ .Values.signalsciences.imageTag }}
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: SIGSCI_ACCESSKEYID
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Release.Name }}-secrets-frontend
+                key: signalsciences_accesskeyid
+          - name: SIGSCI_SECRETACCESSKEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Release.Name }}-secrets-frontend
+                key: signalsciences_secretaccesskey
+        securityContext:
+          readOnlyRootFilesystem: true
+        volumeMounts:
+          - name: sigsci-tmp
+            mountPath: /sigsci/tmp
+        lifecycle:
+          preStop:
+            exec:
+              command: [ "/bin/sleep", "30" ]
+        resources:
+            {{- .Values.signalsciences.resources | toYaml | nindent 10 }}
+        {{- end }}
+
       volumes:
         - name: nginx-conf
           configMap:
@@ -79,6 +117,10 @@ spec:
             items:
               - key: .htaccess
                 path: .htaccess
+        {{- end }}
+        {{- if .Values.signalsciences.enabled }}
+        - name: sigsci-tmp
+          emptyDir: { }
         {{- end }}
 ---
 {{- if .Values.nginx.autoscaling.enabled }}

--- a/charts/frontend/templates/nginx.yaml
+++ b/charts/frontend/templates/nginx.yaml
@@ -110,6 +110,10 @@ spec:
                 path: nginx_conf
               - key: frontend_conf
                 path: frontend_conf
+              {{- if .Values.signalsciences.enabled }}
+              - key: nginx_signalsciences_conf
+                path: nginx_signalsciences_conf
+              {{- end }}
         {{- if .Values.nginx.basicauth.enabled }}
         - name: nginx-basicauth
           secret:

--- a/charts/frontend/templates/secret.yaml
+++ b/charts/frontend/templates/secret.yaml
@@ -7,6 +7,11 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.nginx.basicauth.enabled }}
-  .htaccess: | 
+  .htaccess: |
     {{ printf "%s:{PLAIN}%s" .Values.nginx.basicauth.credentials.username .Values.nginx.basicauth.credentials.password | b64enc }}
+  {{- end }}
+
+  {{- if .Values.signalsciences.enabled }}
+  signalsciences_accesskeyid: {{ .Values.signalsciences.accesskeyid | b64enc | quote }}
+  signalsciences_secretaccesskey: {{ .Values.signalsciences.secretaccesskey | b64enc | quote }}
   {{- end }}

--- a/charts/frontend/values.schema.json
+++ b/charts/frontend/values.schema.json
@@ -68,6 +68,12 @@
     },
     "silta-release": {
       "type": "object"
+    },
+    "signalsciences": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
     }
   }
 }

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -104,7 +104,7 @@ singleSubdomain: false
 
 # These variables are build-specific and should be passed via the --set parameter.
 nginx:
-  image: 'wunderio/silta-nginx:v0.1'
+  image: 'wunderio/silta-nginx:v0.2'
 
   replicas: 1
 

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -36,7 +36,7 @@ app: frontend
 #     hostname: www.example.com
 #   example_no_https:
 #    hostname: insecure.example.com
-#      ssl: 
+#      ssl:
 #        enabled: false
 exposeDomains: {}
 
@@ -84,7 +84,7 @@ ingress:
     #   networking.gke.io/suppress-firewall-xpn-error: "true"
 
 # Infrastructure related settings.
-cluster: 
+cluster:
   type: gke
   vpcNative: false
 
@@ -125,13 +125,13 @@ nginx:
       cpu: 1m
       memory: 10Mi
 
-  loglevel: error 
+  loglevel: error
 
   # Header containing real IP address
   real_ip_header: X-Forwarded-For
 
   # Trust X-Forwarded-For from these hosts for getting external IP
-  realipfrom: 
+  realipfrom:
     gke-internal: 10.0.0.0/8
     gce-health-check-1: 130.211.0.0/22
     gce-health-check-2: 35.191.0.0/16
@@ -140,7 +140,7 @@ nginx:
   # Note that the key is only used for documentation purposes.
   noauthips:
     gke-internal: 10.0.0.0/8
-  
+
   # Set of values to enable and use http basic authentication
   # It is implemented only for very basic protection (like web crawlers)
   basicauth:
@@ -157,7 +157,7 @@ nginx:
     X-Content-Type-Options: 'nosniff'
     X-XSS-Protection: '"1; mode=block"'
     Referrer-Policy: '"no-referrer, strict-origin-when-cross-origin" always'
-  
+
   # includeSubdomains should be used whenever possible, but before enabling it needs to be made sure there are no subdomains not using https:
   hsts_include_subdomains: ""
   #hsts_include_subdomains: " includeSubDomains;"
@@ -195,12 +195,12 @@ services: {}
   #   # When you use exposedRoute, nginx proxies request to service:[/exposedRoute] path.
   #   # This means, you have to implement this path in your application.
   #   #exposedRoute: '/'
-    
+
   #   # How many instances of the Frontend pod should be in our Kubernetes deployment.
   #   # A single pod (the default value) is good for development environments to minimise resource usage.
   #   # Multiple pods make sense for high availability.
   #   replicas: 1
-  
+
   #   # Use storage mountpoints (defined in the mounts section) for this service.
   #   mounts:
   #     - files
@@ -217,7 +217,7 @@ services: {}
   #         name: cpu
   #         targetAverageUtilization: 80
 
-  #   resources: 
+  #   resources:
   #     requests:
   #       cpu: 200m
   #       memory: 128Mi
@@ -266,7 +266,7 @@ mounts: {}
 #    csiDriverName: csi-rclone
 #    accessModes: ReadWriteMany
 
-# Provide SSH access based on GitHub public keys and repository access. 
+# Provide SSH access based on GitHub public keys and repository access.
 # Note: Shell only works when the base image wunderio/silta-node is used!
 shell:
   enabled: false
@@ -426,3 +426,20 @@ rabbitmq:
 #   ENV NODE_OPTIONS="--require /usr/local/lib/node_modules/@instana/collector/src/immediate"
 instana:
   enabled: false
+
+# Fastly Signal Sciences support
+# https://docs.fastly.com/signalsciences/
+signalsciences:
+  enabled: false
+  accesskeyid: ""
+  secretaccesskey: ""
+  image: signalsciences/sigsci-agent
+  imageTag: 4.40.0
+  # sidecar container resources
+  resources:
+    requests:
+      cpu: 20m
+      memory: 40Mi
+    limits:
+      cpu: 40m
+      memory: 80Mi


### PR DESCRIPTION
Allows enabling Fastly Signal Sciences WAF agent for inline request reporting and blocking. This PR requires nginx image change (https://github.com/wunderio/silta-images/pull/101).

Tests can be done by  in the feature/fastly-sigsci-demo branch, which is based on this branch but also contains secret with Sigsci test keys and defines custom image (since nginx image changes ain't merged yet).

Source: https://docs.fastly.com/signalsciences/install-guides/kubernetes/kubernetes-agent-module/