### PR TITLE
Support for secrets as environment variables

### DIFF
--- a/charts/frontend/templates/_helpers.tpl
+++ b/charts/frontend/templates/_helpers.tpl
@@ -137,7 +137,7 @@ rsync -az /values_mounts/ /backups/current/
   value: .svc.cluster.local,{{ .Release.Name }}-mongodb,{{ .Release.Name }}-es{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
 - name: NO_PROXY
   value: .svc.cluster.local,{{ .Release.Name }}-mongodb,{{ .Release.Name }}-es{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
-{{- end }}
+{{- end -}}
 {{ if .Values.instana.enabled -}}
 # Instana
 - name: INSTANA_AGENT_HOST

--- a/charts/frontend/templates/services-cron.yaml
+++ b/charts/frontend/templates/services-cron.yaml
@@ -41,7 +41,11 @@ spec:
             {{- include "services.env" (dict "Values" $.Values "Release" $.Release "service" $service) | nindent 12 }}
             {{- range $key, $val := $service.env }}
             - name: {{ $key }}
+            {{- if kindIs "string" $val }}
               value: {{ $val | quote }}
+            {{- else }}
+              {{ $val | toYaml | indent 14 | trim }}
+            {{- end }}
             {{- end }}
             command: ["/bin/sh", "-c"]
             args:

--- a/charts/frontend/templates/services-deployment.yaml
+++ b/charts/frontend/templates/services-deployment.yaml
@@ -66,10 +66,14 @@ spec:
         {{- include "services.env" (dict "Values" $.Values "Release" $.Release "service" $service) | nindent 8 }}
         {{- range $key, $val := $service.env }}
         - name: {{ $key }}
+        {{- if kindIs "string" $val }}
           value: {{ $val | quote }}
+        {{- else }}
+          {{ $val | toYaml | indent 8 | trim }}
+        {{- end }}
         {{- end }}
         resources:
-          {{ if $service.resources -}}
+          {{- if $service.resources -}}
           {{ merge $service.resources $.Values.serviceDefaults.resources | toYaml | nindent 10 }}
           {{ else -}}
           {{ $.Values.serviceDefaults.resources | toYaml | nindent 10 }}
@@ -194,7 +198,11 @@ spec:
         {{- include "services.env" (dict "Values" $.Values "Release" $.Release "service" $service) | nindent 8 }}
         {{- range $key, $val := $service.env }}
         - name: {{ $key }}
+        {{- if kindIs "string" $val }}
           value: {{ $val | quote }}
+        {{- else }}
+          {{ $val | toYaml | indent 4 | trim }}
+        {{- end }}
         {{- end }}
       volumes:
         {{ if $service.mounts }}

--- a/charts/frontend/templates/services-deployment.yaml
+++ b/charts/frontend/templates/services-deployment.yaml
@@ -69,7 +69,7 @@ spec:
         {{- if kindIs "string" $val }}
           value: {{ $val | quote }}
         {{- else }}
-          {{ $val | toYaml | indent 8 | trim }}
+          {{ $val | toYaml | indent 12 | trim }}
         {{- end }}
         {{- end }}
         resources:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -31,6 +31,12 @@ services:
   world:
     exposedRoute: '/world'
     port: 5000
+    env:
+      secret_TEST:
+        valueFrom:
+          secretKeyRef:
+            name: secret-resource
+            key: somefield
     replicas: 2
     mounts:
       - files

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -31,12 +31,6 @@ services:
   world:
     exposedRoute: '/world'
     port: 5000
-    env:
-      secret_TEST:
-        valueFrom:
-          secretKeyRef:
-            name: secret-resource
-            key: somefield
     replicas: 2
     mounts:
       - files


### PR DESCRIPTION
Secrets can be referenced as environment variables for service pods, cronjobs.
Removed some empty lines from resource templates.

### Testing
1. Create a secret `kubectl create secret generic secret-resource --from-literal=somefield=somedata -n frontend-project-k8s`
2. Update `silta.yml` with secret env vars
```
  world:
    exposedRoute: '/world'
    port: 5000
    env:
      secret_TEST:
        valueFrom:
          secretKeyRef:
            name: secret-resource
            key: somefield
```
4. After deployment, exec into `<branch>-world` container. There should be an environment variable `secret_TEST`, with a value defined in secret `secret-resource`, from a field `somefield`.
5. Look up cronjob definition for `<branch>-world-cli`. It should have the same env var as in step 4.

Locally, I inspect the rendered template by running `helm template <release name> ./charts/frontend --debug --values silta/silta.yml | less`
Release name can be made up.