### PR TITLE
Feature/secrets mount

### DIFF
--- a/charts/frontend/templates/services-deployment.yaml
+++ b/charts/frontend/templates/services-deployment.yaml
@@ -210,8 +210,16 @@ spec:
         {{ $mount := (index $.Values.mounts $mountName) }}
         {{- if eq $mount.enabled true }}
         - name: frontend-{{ $mountName }}
+        {{- if hasKey $mount "secretName" }}
+          secret:
+            secretName: {{ $mount.secretName }}
+        {{- else if hasKey $mount "configMapName" }}
+          configMap:
+            name: {{ $mount.configMapName }}
+        {{- else }}
           persistentVolumeClaim:
             claimName: {{ $.Release.Name }}-{{ $mountName }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/charts/frontend/templates/services-deployment.yaml
+++ b/charts/frontend/templates/services-deployment.yaml
@@ -80,8 +80,16 @@ spec:
         {{ $mount := (index $.Values.mounts $mountName) }}
         {{- if eq $mount.enabled true }}
         - name: frontend-{{ $mountName }}
+        {{- if hasKey $mount "secretName" }}
+          secret:
+            secretName: {{ $mount.secretName }}
+        {{- else if hasKey $mount "configMapName" }}
+          configMap:
+            name: {{ $mount.configMapName }}
+        {{- else }}
           persistentVolumeClaim:
             claimName: {{ $.Release.Name }}-{{ $mountName }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/charts/frontend/templates/volumes.yaml
+++ b/charts/frontend/templates/volumes.yaml
@@ -1,5 +1,6 @@
 {{- range $index, $mount := .Values.mounts }}
 {{- if $mount.enabled }}
+{{- if and (not (hasKey $mount "configMapName")) (not (hasKey $mount "secretName")) -}}
 {{- if eq $mount.storageClassName "silta-shared" }}
 # Mount-enabled: {{ $mount.enabled  }}
 apiVersion: v1
@@ -45,6 +46,7 @@ spec:
 {{- end }}
 ---
 {{- end -}}
+{{- end }}
 {{- end }}
 
 {{- if $.Values.shell.enabled }}

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -21,8 +21,6 @@ services:
       tcpSocket:
         port: 4000
       initialDelaySeconds: 30
-    mounts:
-      - test-cm
     postinstall:
       command: |
         echo Postinstall command executed
@@ -36,7 +34,6 @@ services:
     replicas: 2
     mounts:
       - files
-      - test-secret
     cron:
       world-cli:
         command: echo $(date) > /app/files/lastupdate.txt
@@ -54,14 +51,6 @@ mounts:
     mountPath: /app/files
     storageClassName: silta-shared
     csiDriverName: csi-rclone
-  test-secret:
-    enabled: true
-    secretName: test-secret
-    mountPath: /a-secret
-  test-cm:
-    enabled: true
-    configMapName: test-cm
-    mountPath: /a-cm
 
 shell:
   enabled: true

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -21,6 +21,8 @@ services:
       tcpSocket:
         port: 4000
       initialDelaySeconds: 30
+    mounts:
+      - test-cm
     postinstall:
       command: |
         echo Postinstall command executed
@@ -34,6 +36,7 @@ services:
     replicas: 2
     mounts:
       - files
+      - test-secret
     cron:
       world-cli:
         command: echo $(date) > /app/files/lastupdate.txt
@@ -51,6 +54,14 @@ mounts:
     mountPath: /app/files
     storageClassName: silta-shared
     csiDriverName: csi-rclone
+  test-secret:
+    enabled: true
+    secretName: test-secret
+    mountPath: /a-secret
+  test-cm:
+    enabled: true
+    configMapName: test-cm
+    mountPath: /a-cm
 
 shell:
   enabled: true


### PR DESCRIPTION
Option to reference secrets, configmaps in mounts.

### Testing
1. Create a secret `kubectl create secret generic test-secret --from-literal=somefield=somedata -n frontend-project-k8s`
2. Create a configmap `kubectl create configmap test-cm --from-literal=special.how=very --from-literal=special.type=charm -n frontend-project-k8s`
3. Add both mount types to `mounts:` in silta.yml
```
  test-secret:
    enabled: true
    secretName: test-secret
    mountPath: /a-secret
  test-cm:
    enabled: true
    configMapName: test-cm
    mountPath: /a-cm
```
4. Reference both mounts to pods
```
services:
  hello:
    [...]
    mounts:
      - test-cm
    [...]
  world:
    [...]
    mounts:
      - files
      - test-secret
    [...]  
```
5. After deployment, exec into `hello` pod; there should be a directory `/a-cm`. For `world` pod, it will be `/a-secret` directory.