### PR TITLE
Mailhog support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,11 +86,11 @@ workflows:
                 path: '.'
                 identifier: 'world'
             - run:
-                name: Add elastic repo for elasticsearch
-                command: helm repo add elastic https://helm.elastic.co
-            - run:
-                name: Build local helm dependencies
-                command: helm dependency build ./charts/frontend
+                name: Add helm repositories and build local chart
+                command: |
+                  helm repo add elastic https://helm.elastic.co
+                  helm repo add codecentric https://codecentric.github.io/helm-charts
+                  helm dependency build ./charts/frontend
             - run:
                 name: Dry-run helm install
                 command: helm install --dry-run --generate-name ./charts/frontend --values charts/frontend/test.values.yaml
@@ -201,11 +201,11 @@ workflows:
                 path: '.'
                 identifier: 'world'
             - run:
-                name: Add elastic repo for elasticsearch
-                command: helm repo add elastic https://helm.elastic.co
-            - run:
-                name: Build local helm dependencies
-                command: helm dependency build ./charts/frontend
+                name: Add helm repositories and build local chart
+                command: |
+                  helm repo add elastic https://helm.elastic.co
+                  helm repo add codecentric https://codecentric.github.io/helm-charts
+                  helm dependency build ./charts/frontend
             - run:
                 name: Dry-run helm install
                 command: helm install --dry-run --generate-name ./charts/frontend --values charts/frontend/test.values.yaml

--- a/charts/frontend/Chart.lock
+++ b/charts/frontend/Chart.lock
@@ -2,6 +2,9 @@ dependencies:
 - name: mariadb
   repository: https://storage.googleapis.com/charts.wdr.io
   version: 7.10.4
+- name: mailhog
+  repository: https://codecentric.github.io/helm-charts
+  version: 5.1.0
 - name: elasticsearch
   repository: file://../elasticsearch
   version: 8.5.1
@@ -14,5 +17,5 @@ dependencies:
 - name: silta-release
   repository: file://../silta-release
   version: 1.0.0
-digest: sha256:7b090077d70021edfb2479e8efaa4079246a09c3d9fb7d1ae56a93ae37240d82
-generated: "2023-10-03T12:01:47.209153798+03:00"
+digest: sha256:c356de05b806d3ca439e2eeea4ee23b206e8c4912818806ae6c65227005c3757
+generated: "2023-11-13T13:00:16.425472744+02:00"

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -6,6 +6,10 @@ dependencies:
   version: 7.10.x
   repository: https://storage.googleapis.com/charts.wdr.io
   condition: mariadb.enabled
+- name: mailhog
+  version: 5.1.x
+  repository: https://codecentric.github.io/helm-charts
+  condition: mailhog.enabled
 - name: elasticsearch
   version: 8.5.x
   # repository: https://helm.elastic.co

--- a/charts/frontend/templates/NOTES.txt
+++ b/charts/frontend/templates/NOTES.txt
@@ -19,6 +19,16 @@ Deployed {{ .Release.Name }} successfully, your site is available here:
   Basicauth password: {{ .Values.nginx.basicauth.credentials.password }}
   {{- end }}
 
+{{- if .Values.mailhog.enabled }}
+  
+Mailhog available at:
+
+  http://{{- template "frontend.domain" . }}/mailhog
+  {{- range $index, $domain := .Values.exposeDomains }}
+  http://{{ $domain.hostname }}/mailhog
+  {{- end }}
+{{- end }}
+
 {{ if $.Values.shell.enabled }}
 SSH connection (limited access through VPN):
   {{ range $index, $service := .Values.services }}

--- a/charts/frontend/templates/_helpers.tpl
+++ b/charts/frontend/templates/_helpers.tpl
@@ -145,6 +145,17 @@ rsync -az /values_mounts/ /backups/current/
     fieldRef:
       fieldPath: status.hostIP
 {{- end }}
+{{- if .Values.mailhog.enabled }}
+{{- if .Values.mailhog.enabled }}
+{{- if contains "mailhog" .Release.Name -}}
+{{- fail "Do not use 'mailhog' in release name or deployment will fail" -}}
+{{- end }}
+{{- end }}
+{{- if .Values.mailhog.enabled }}
+- name: MAILHOG_ADDRESS
+  value: "{{ .Release.Name }}-mailhog:1025"
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{- define "cert-manager.api-version" }}

--- a/charts/frontend/templates/_helpers.tpl
+++ b/charts/frontend/templates/_helpers.tpl
@@ -146,15 +146,11 @@ rsync -az /values_mounts/ /backups/current/
       fieldPath: status.hostIP
 {{- end }}
 {{- if .Values.mailhog.enabled }}
-{{- if .Values.mailhog.enabled }}
 {{- if contains "mailhog" .Release.Name -}}
 {{- fail "Do not use 'mailhog' in release name or deployment will fail" -}}
 {{- end }}
-{{- end }}
-{{- if .Values.mailhog.enabled }}
 - name: MAILHOG_ADDRESS
   value: "{{ .Release.Name }}-mailhog:1025"
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/frontend/templates/checks.yaml
+++ b/charts/frontend/templates/checks.yaml
@@ -1,0 +1,7 @@
+{{- if index (index .Values "silta-release") "branchName" }}
+{{- if eq (index (index .Values "silta-release") "branchName") "production" }}
+{{- if .Values.mailhog.enabled }}
+{{- fail "Mailhog should not be enabled in production" -}}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/frontend/templates/configmap.yaml
+++ b/charts/frontend/templates/configmap.yaml
@@ -154,6 +154,40 @@ data:
 
         include fastcgi.conf;
 
+        {{- if .Values.mailhog.enabled }}
+        location /mailhog {
+
+          # Auth / whitelist always enabled
+          satisfy any;
+          allow 127.0.0.1;
+          {{- range .Values.nginx.noauthips }}
+          allow {{ . }};
+          {{- end }}
+          deny all;
+
+          {{- if gt (len .Values.nginx.noauthips) 1 -}}
+          # Basic auth only offered when at least one extra ip is whitelisted. Prevents using default credentials.
+          auth_basic "Restricted";
+          auth_basic_user_file /etc/nginx/.htaccess;
+          {{- end}}
+
+          rewrite ^/mailhog$ /mailhog/ permanent;
+
+          # Proxy to mailhog container
+          rewrite /mailhog(.*) $1 break;
+          proxy_pass http://{{ .Release.Name }}-mailhog:8025/;
+
+          # Websock connection
+          chunked_transfer_encoding on;
+          proxy_set_header X-NginX-Proxy true;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+          proxy_http_version 1.1;
+          proxy_redirect off;
+            proxy_buffering off;
+        }
+        {{- end}}
+
         # Custom configuration gets included here
         {{- tpl .Values.nginx.serverExtraConfig . | nindent 8 -}}
 

--- a/charts/frontend/test.values.yaml
+++ b/charts/frontend/test.values.yaml
@@ -28,6 +28,9 @@ shell:
 elasticsearch:
   enabled: true
 
+mailhog:
+  enabled: true
+
 mongodb:
   enabled: true
 

--- a/charts/frontend/tests/elasticsearch_test.yaml
+++ b/charts/frontend/tests/elasticsearch_test.yaml
@@ -1,4 +1,4 @@
-suite: drupal elasticsearch
+suite: frontend elasticsearch
 templates:
   - services-deployment.yaml
   - configmap.yaml
@@ -6,7 +6,7 @@ capabilities:
   apiVersions:
     - pxc.percona.com/v1
 tests:
-  - it: sets elasticsearch hostname in drupal environment if elasticsearch is enabled
+  - it: sets elasticsearch hostname in environment if elasticsearch is enabled
     template: services-deployment.yaml
     set:
       services.node.enabled: true
@@ -18,7 +18,7 @@ tests:
             name: ELASTICSEARCH_HOST
             value: RELEASE-NAME-es
 
-  - it: sets no elasticsearch hostname in drupal environment if elasticsearch is disabled
+  - it: sets no elasticsearch hostname in environment if elasticsearch is disabled
     template: services-deployment.yaml
     set:
       services.node.enabled: true

--- a/charts/frontend/values.schema.json
+++ b/charts/frontend/values.schema.json
@@ -456,6 +456,21 @@
         "enabled": { "type": "boolean" }
       }
     },
+    "mailhog": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string" }
+          }
+        }
+      }
+    },
     "silta-release": {
       "type": "object"
     },

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -452,3 +452,17 @@ signalsciences:
     limits:
       cpu: 40m
       memory: 300Mi
+
+# Mailhog service overrides
+# see: https://github.com/codecentric/helm-charts/blob/master/charts/mailhog/values.yaml
+mailhog:
+  enabled: false
+  image:
+    # Set image repository to "mailhog/mailhog" to reenable logging.
+    repository: wunderio/silta-mailhog
+    # Set image tag to "" to reenable logging.
+    tag: v1
+  resources:
+    requests:
+      cpu: 1m
+      memory: 10M


### PR DESCRIPTION
Starts mailhog server when enabled via `mailhog.enabled=true`. 
It's available on port 1025 internally for backends (use `MAILHOG_ADDRESS` environment variable), web interface exposed on `/mailhog` path and only when there are at least two IP's defined at at `nginx.noauthips`.
