### PR TITLE
reenabling postgres subchart

### DIFF
--- a/charts/frontend/Chart.lock
+++ b/charts/frontend/Chart.lock
@@ -14,8 +14,11 @@ dependencies:
 - name: mongodb
   repository: https://storage.googleapis.com/charts.wdr.io
   version: 10.26.4
+- name: postgresql
+  repository: https://storage.googleapis.com/charts.wdr.io
+  version: 13.2.24
 - name: silta-release
   repository: file://../silta-release
   version: 1.0.0
-digest: sha256:c356de05b806d3ca439e2eeea4ee23b206e8c4912818806ae6c65227005c3757
-generated: "2023-12-12T18:53:09.289992471+02:00"
+digest: sha256:95eb80d5b21e1fb9cf5c0bf1b917801d027df824b84fcb6cd4d377fcb6a542b4
+generated: "2023-12-13T16:17:41.789630834+02:00"

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -24,11 +24,11 @@ dependencies:
   version: 10.26.x
   repository: https://storage.googleapis.com/charts.wdr.io
   condition: mongodb.enabled
-# - name: postgresql
-#   version: 13.2.x
-#   # repository: https://charts.bitnami.com/bitnami
-#   repository: https://storage.googleapis.com/charts.wdr.io
-#   condition: postgresql.enabled
+- name: postgresql
+  version: 13.2.x
+  # repository: https://charts.bitnami.com/bitnami
+  repository: https://storage.googleapis.com/charts.wdr.io
+  condition: postgresql.enabled
 - name: silta-release
   version: ^1.x
   repository: file://../silta-release

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -433,13 +433,13 @@ mongodb:
   persistence:
     size: 1Gi
 
-# # Posgresql overrides
-# # see: https://github.com/bitnami/charts/blob/c3dc56f3679650f1012e497b8a5e71d94dac163e/bitnami/postgresql/values.yaml
-# postgresql:
-#   enabled: false
-#   # Use a low default to prevent unnecessary storage use.
-#   persistence:
-#     size: 1Gi
+# Posgresql overrides
+# see: https://github.com/bitnami/charts/blob/c3dc56f3679650f1012e497b8a5e71d94dac163e/bitnami/postgresql/values.yaml
+postgresql:
+  enabled: false
+  # Use a low default to prevent unnecessary storage use.
+  persistence:
+    size: 1Gi
 
 rabbitmq:
   enabled: false


### PR DESCRIPTION
reenables postgres subchart.

blocked by:
1. https://github.com/wunderio/silta-images/pull/167
2. https://github.com/wunderio/drupal-project-k8s/pull/679