### PR TITLE
Timezone support

### DIFF
--- a/charts/frontend/templates/_helpers.tpl
+++ b/charts/frontend/templates/_helpers.tpl
@@ -71,6 +71,10 @@ rsync -az /values_mounts/ /backups/current/
 - name: "{{ $index }}_HOST"
   value: "{{ $.Release.Name }}-{{ $index }}:{{ default $.Values.serviceDefaults.port $service.port }}"
 {{- end }}
+{{- if .Values.timezone }}
+- name: TZ
+  value: {{ .Values.timezone | quote }}
+{{- end }}
 # Elasticsearch
 {{- if .Values.elasticsearch.enabled }}
 - name: ELASTICSEARCH_HOST
@@ -175,6 +179,12 @@ networking.k8s.io/v1beta1
 batch/v1
 {{- else }}
 batch/v1beta1
+{{- end }}
+{{- end }}
+
+{{- define "frontend.cron.timezone-support" }}
+{{- if and ( ge $.Capabilities.KubeVersion.Major "1") ( ge $.Capabilities.KubeVersion.Minor "25" ) }}true
+{{- else }}false
 {{- end }}
 {{- end }}
 

--- a/charts/frontend/templates/backup-cron.yaml
+++ b/charts/frontend/templates/backup-cron.yaml
@@ -6,6 +6,11 @@ metadata:
   labels:
     cronjob-type: backup
 spec:
+  {{- if .Values.timezone }}
+  {{- if eq ( include "frontend.cron.timezone-support" . ) "true" }}
+  timeZone: {{ .Values.timezone | quote }}
+  {{- end }}
+  {{- end }}
   schedule: {{ .Values.backup.schedule | replace "~" (randNumeric 1) | quote }}
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 3600

--- a/charts/frontend/templates/services-cron.yaml
+++ b/charts/frontend/templates/services-cron.yaml
@@ -1,7 +1,6 @@
 {{- range $serviceName, $service := .Values.services }}
 {{- if $service.cron }}
 {{- range $jobName, $job := $service.cron }}
-
 apiVersion: {{ include "frontend.cron.api-version" $ | trim }}
 kind: CronJob
 metadata:
@@ -9,6 +8,11 @@ metadata:
   labels:
     {{- include "frontend.release_labels" $ | nindent 4 }}
 spec:
+  {{- if $.Values.timezone }}
+  {{- if eq ( include "frontend.cron.timezone-support" $ ) "true" }}
+  timeZone: {{ $.Values.timezone | quote }}
+  {{- end }}
+  {{- end }}
   schedule: {{ $job.schedule | replace "~" (randNumeric 1) | quote }}
   concurrencyPolicy: {{ default "Forbid" $job.concurrencyPolicy }}
   startingDeadlineSeconds: 3600

--- a/charts/frontend/tests/services-cron_test.yaml
+++ b/charts/frontend/tests/services-cron_test.yaml
@@ -173,3 +173,27 @@ tests:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].resources.requests.memory
           value: 2Mi
+
+  - it: can set timezone
+    template: services-cron.yaml
+    set:
+      timezone: 'Foo/Bar'
+      services.foo:
+        image: 'bar'
+        cron:
+          foo:
+            command: echo "Hello world"
+            schedule: '1 2 3 * *'
+    capabilities:
+      majorVersion: 1
+      minorVersion: 25
+    asserts:
+      - equal:
+          path: spec.timeZone
+          value: 'Foo/Bar'
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: TZ
+            value: Foo/Bar
+        

--- a/charts/frontend/values.schema.json
+++ b/charts/frontend/values.schema.json
@@ -96,7 +96,7 @@
         "vpcNative": { "type": "boolean" }
       }
     },
-    
+    "timezone": { "type": "string" },
     "nginx": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -88,6 +88,9 @@ cluster:
   type: gke
   vpcNative: false
 
+# Timezone to be used by the services that support it.
+# List of timezones: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List (use the TZ identifier column)
+# The default timezone for most container images is UTC.
 timezone: ""
 
 # backendConfig customizations for main service

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -88,6 +88,8 @@ cluster:
   type: gke
   vpcNative: false
 
+timezone: ""
+
 # backendConfig customizations for main service
 backendConfig:
   securityPolicy:


### PR DESCRIPTION
Allows setting timezone for service cronjobs ([beta since 1.25](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones)) and TZ environment variables for frontend services