### PR TITLE
SLT-1001: Support for Mongo 7.0.5

### DIFF
--- a/charts/frontend/Chart.lock
+++ b/charts/frontend/Chart.lock
@@ -12,13 +12,13 @@ dependencies:
   repository: https://storage.googleapis.com/charts.wdr.io
   version: 6.17.5
 - name: mongodb
-  repository: https://storage.googleapis.com/charts.wdr.io
-  version: 10.26.4
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 14.12.3
 - name: postgresql
   repository: https://storage.googleapis.com/charts.wdr.io
   version: 13.2.24
 - name: silta-release
   repository: file://../silta-release
   version: 1.0.0
-digest: sha256:95eb80d5b21e1fb9cf5c0bf1b917801d027df824b84fcb6cd4d377fcb6a542b4
-generated: "2023-12-13T16:17:41.789630834+02:00"
+digest: sha256:ce1f9c915208446fda93af256bf502b3cd71d978ae2806c0e988c5d2a8b02ca6
+generated: "2024-03-05T15:38:09.328520813+02:00"

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -21,8 +21,8 @@ dependencies:
   repository: https://storage.googleapis.com/charts.wdr.io
   condition: rabbitmq.enabled
 - name: mongodb
-  version: 10.26.x
-  repository: https://storage.googleapis.com/charts.wdr.io
+  version: 14.12.x
+  repository: oci://registry-1.docker.io/bitnamicharts
   condition: mongodb.enabled
 - name: postgresql
   version: 13.2.x

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -477,11 +477,11 @@ elasticsearch:
           - static-ip
 
 # These settings are not optimized. To see which overrides are available see:
-# https://github.com/bitnami/charts/blob/master/bitnami/mongodb/values.yaml
+# https://github.com/bitnami/charts/blob/43306df9f67a6c38743cac362676317aa7a8318e/bitnami/mongodb/values.yaml
 mongodb:
   enabled: false
   image:
-    tag: 5.0.3
+    tag: 7.0.6-debian-12-r0
   updateStrategy:
     type: Recreate
 

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -481,7 +481,7 @@ elasticsearch:
 mongodb:
   enabled: false
   image:
-    tag: 6.0.13-debian-11-r21
+    tag: 6.0
   initdbScripts:
     setFeatureCompatibilityVersion.js: |
       db.adminCommand({ setFeatureCompatibilityVersion: "6.0" });

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -482,6 +482,9 @@ mongodb:
   enabled: false
   image:
     tag: 5.0.3
+  updateStrategy:
+    type: Recreate
+
 
   # Use a low default to prevent unnecessary storage use.
   persistence:

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -484,8 +484,9 @@ mongodb:
     tag: 7.0.6-debian-12-r0
   updateStrategy:
     type: Recreate
-
-
+  initdbScripts:
+    setFeatureCompatibilityVersion.js: |
+      db.adminCommand({ setFeatureCompatibilityVersion: "7.0", confirm: true);
   # Use a low default to prevent unnecessary storage use.
   persistence:
     size: 1Gi

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -481,12 +481,13 @@ elasticsearch:
 mongodb:
   enabled: false
   image:
-    tag: 7.0.6-debian-12-r0
-  updateStrategy:
-    type: Recreate
+    tag: 6.0.13-debian-11-r21
   initdbScripts:
     setFeatureCompatibilityVersion.js: |
-      db.adminCommand({ setFeatureCompatibilityVersion: "7.0", confirm: true);
+      db.adminCommand({ setFeatureCompatibilityVersion: "6.0" });
+  updateStrategy:
+    type: Recreate
+  enableServiceLinks: false
   # Use a low default to prevent unnecessary storage use.
   persistence:
     size: 1Gi

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -64,3 +64,8 @@ silta-release:
 
 varnish:
   enabled: true
+
+mongodb:
+  enabled: true
+  # image:
+  #   tag: 5.0.3

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -67,9 +67,3 @@ varnish:
 
 mongodb:
   enabled: true
-  # image:
-  #   tag: 6.0.13-debian-11-r21
-  # initdbScripts:
-  #   setFeatureCompatibilityVersion.js: |
-  #     db.adminCommand({ setFeatureCompatibilityVersion: "7.0");
-  

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -68,4 +68,8 @@ varnish:
 mongodb:
   enabled: true
   # image:
-  #   tag: 5.0.3
+  #   tag: 6.0.13-debian-11-r21
+  # initdbScripts:
+  #   setFeatureCompatibilityVersion.js: |
+  #     db.adminCommand({ setFeatureCompatibilityVersion: "7.0");
+  


### PR DESCRIPTION
Updates mongodb chart and sets image to 6 by default to provide upgrade path for existing chart (current chart runs mongodb 5). This allows running mongodb 7 if needed.