### PR TITLE
Add redis support

### DIFF
--- a/charts/frontend/Chart.lock
+++ b/charts/frontend/Chart.lock
@@ -20,5 +20,8 @@ dependencies:
 - name: silta-release
   repository: file://../silta-release
   version: 1.0.0
-digest: sha256:95eb80d5b21e1fb9cf5c0bf1b917801d027df824b84fcb6cd4d377fcb6a542b4
-generated: "2023-12-13T16:17:41.789630834+02:00"
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 18.19.2
+digest: sha256:d30ca54c5789b9a601e7a2c30c8882e5c21475e0c0da58bf79daab978d82244f
+generated: "2024-03-13T14:19:26.173094653+01:00"

--- a/charts/frontend/Chart.lock
+++ b/charts/frontend/Chart.lock
@@ -21,7 +21,7 @@ dependencies:
   repository: file://../silta-release
   version: 1.0.0
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 18.19.4
-digest: sha256:260dbf74bcb76f7b4a6cfdf4efc68afd6631c1ccc8679f0cd070625b30599073
-generated: "2024-04-24T13:28:57.413453012+03:00"
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 19.1.5
+digest: sha256:b494e7a5c8be4e2c9478ba2af95fa91830a6f537bdafc30c1c1399b4024168c3
+generated: "2024-05-02T08:45:24.766124978+03:00"

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -33,6 +33,6 @@ dependencies:
   version: ^1.x
   repository: file://../silta-release
 - name: redis
-  version: 18.19.x
-  repository: https://charts.bitnami.com/bitnami
+  version: 19.1.5
+  repository: oci://registry-1.docker.io/bitnamicharts
   condition: redis.enabled

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -1,38 +1,38 @@
 apiVersion: v2
 name: frontend
-version: 1.7.0
+version: 1.6.0
 dependencies:
-- name: mariadb
-  version: 7.10.x
-  repository: https://storage.googleapis.com/charts.wdr.io
-  condition: mariadb.enabled
-- name: mailhog
-  version: 5.1.x
-  repository: https://codecentric.github.io/helm-charts
-  condition: mailhog.enabled
-- name: elasticsearch
-  version: 8.5.x
-  # repository: https://helm.elastic.co
-  # Forked at https://github.com/elastic/helm-charts/commit/2fd64d0af65f14df7aa01da591919460dabac4b3
-  repository: file://../elasticsearch
-  condition: elasticsearch.enabled
-- name: rabbitmq
-  version: 6.17.x
-  repository: https://storage.googleapis.com/charts.wdr.io
-  condition: rabbitmq.enabled
-- name: mongodb
-  version: 10.26.x
-  repository: https://storage.googleapis.com/charts.wdr.io
-  condition: mongodb.enabled
-- name: postgresql
-  version: 13.2.x
-  # repository: https://charts.bitnami.com/bitnami
-  repository: https://storage.googleapis.com/charts.wdr.io
-  condition: postgresql.enabled
-- name: silta-release
-  version: ^1.x
-  repository: file://../silta-release
-- name: redis
-  version: 18.19.x
-  repository: https://charts.bitnami.com/bitnami
-  condition: redis.enabled
+  - name: mariadb
+    version: 7.10.x
+    repository: https://storage.googleapis.com/charts.wdr.io
+    condition: mariadb.enabled
+  - name: mailhog
+    version: 5.1.x
+    repository: https://codecentric.github.io/helm-charts
+    condition: mailhog.enabled
+  - name: elasticsearch
+    version: 8.5.x
+    # repository: https://helm.elastic.co
+    # Forked at https://github.com/elastic/helm-charts/commit/2fd64d0af65f14df7aa01da591919460dabac4b3
+    repository: file://../elasticsearch
+    condition: elasticsearch.enabled
+  - name: rabbitmq
+    version: 6.17.x
+    repository: https://storage.googleapis.com/charts.wdr.io
+    condition: rabbitmq.enabled
+  - name: mongodb
+    version: 10.26.x
+    repository: https://storage.googleapis.com/charts.wdr.io
+    condition: mongodb.enabled
+  - name: postgresql
+    version: 13.2.x
+    # repository: https://charts.bitnami.com/bitnami
+    repository: https://storage.googleapis.com/charts.wdr.io
+    condition: postgresql.enabled
+  - name: silta-release
+    version: ^1.x
+    repository: file://../silta-release
+  - name: redis
+    version: 18.19.x
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 1.6.0
+version: 1.7.0
 dependencies:
 - name: mariadb
   version: 7.10.x
@@ -32,3 +32,7 @@ dependencies:
 - name: silta-release
   version: ^1.x
   repository: file://../silta-release
+- name: redis
+  version: 18.19.x
+  repository: https://charts.bitnami.com/bitnami
+  condition: redis.enabled

--- a/charts/frontend/templates/_helpers.tpl
+++ b/charts/frontend/templates/_helpers.tpl
@@ -134,6 +134,21 @@ rsync -az /values_mounts/ /backups/current/
 - name: OUTSIDE_COLLABORATORS
   value: {{ .Values.shell.gitAuth.outsideCollaborators | default true | quote }}
 {{- end }}
+{{- if .Values.redis.enabled }}
+{{- if contains "redis" .Release.Name -}}
+{{- fail "Do not use 'redis' in release name or deployment will fail" -}}
+{{- end }}
+{{- if eq .Values.redis.auth.password "" }}
+{{- fail ".Values.redis.auth.password value required." }}
+{{- end }}
+- name: REDIS_HOST
+  value: {{ .Release.Name }}-redis-master
+- name: REDIS_PASS
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-redis
+      key: redis-password
+{{- end }}
 # Proxy
 {{ $proxy := ( index .Values "silta-release" ).proxy }}
 {{ if $proxy.enabled }}
@@ -149,9 +164,9 @@ rsync -az /values_mounts/ /backups/current/
 - name: HTTPS_PROXY
   value: "{{ $proxy.url }}:{{ $proxy.port }}"
 - name: no_proxy
-  value: .svc.cluster.local,{{ .Release.Name }}-mongodb,{{ .Release.Name }}-es{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
+  value: .svc.cluster.local,{{ .Release.Name }}-mongodb,{{ .Release.Name }}-redis,{{ .Release.Name }}-es{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
 - name: NO_PROXY
-  value: .svc.cluster.local,{{ .Release.Name }}-mongodb,{{ .Release.Name }}-es{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
+  value: .svc.cluster.local,{{ .Release.Name }}-mongodb,{{ .Release.Name }}-redis,{{ .Release.Name }}-es{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
 {{- end -}}
 {{ if .Values.instana.enabled -}}
 # Instana

--- a/charts/frontend/test.values.yaml
+++ b/charts/frontend/test.values.yaml
@@ -38,6 +38,12 @@ mongodb:
 rabbitmq:
   enabled: true
 
+redis:
+  enabled: true
+  auth:
+    password: foo
+
+
 mounts:
   files:
     enabled: true

--- a/charts/frontend/test.values.yaml
+++ b/charts/frontend/test.values.yaml
@@ -41,7 +41,7 @@ rabbitmq:
 redis:
   enabled: true
   auth:
-    password: foo
+    password: "foo"
 
 
 mounts:

--- a/charts/frontend/tests/redis_test.yaml
+++ b/charts/frontend/tests/redis_test.yaml
@@ -1,0 +1,32 @@
+suite: drupal redis
+templates:
+  - services-deployment.yaml
+  - configmap.yaml
+capabilities:
+  apiVersions:
+    - pxc.percona.com/v1
+tests:
+  - it: sets redis hostname in drupal environment if redis is enabled
+    template: services-deployment.yaml
+    set:
+      redis:
+        enabled: true
+        auth:
+          password: "foo"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_HOST
+            value: RELEASE-NAME-redis-master
+
+  - it: sets no redis hostname in frontend environment if redis is disabled
+    template: services-deployment.yaml
+    set:
+      redis.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_HOST
+            value: RELEASE-NAME-redis-master

--- a/charts/frontend/tests/redis_test.yaml
+++ b/charts/frontend/tests/redis_test.yaml
@@ -1,4 +1,4 @@
-suite: drupal redis
+suite: frontend redis
 templates:
   - services-deployment.yaml
   - configmap.yaml
@@ -6,9 +6,10 @@ capabilities:
   apiVersions:
     - pxc.percona.com/v1
 tests:
-  - it: sets redis hostname in drupal environment if redis is enabled
+  - it: sets redis hostname in environment if redis is enabled
     template: services-deployment.yaml
     set:
+      services.node.enabled: true
       redis:
         enabled: true
         auth:
@@ -23,6 +24,7 @@ tests:
   - it: sets no redis hostname in frontend environment if redis is disabled
     template: services-deployment.yaml
     set:
+      services.node.enabled: true
       redis.enabled: false
     asserts:
       - notContains:

--- a/charts/frontend/values.schema.json
+++ b/charts/frontend/values.schema.json
@@ -529,6 +529,13 @@
         "enabled": { "type": "boolean" }
       }
     },
+    "redis": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
     "mailhog": {
       "type": "object",
       "properties": {

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -538,3 +538,25 @@ mailhog:
     requests:
       cpu: 1m
       memory: 10M
+
+# Redis
+# https://github.com/bitnami/charts/blob/master/bitnami/redis/values.yaml
+redis:
+  enabled: false
+  architecture: standalone
+  auth:
+    # mandatory value
+    password: ""
+  replica:
+    # replicaCount: 1
+    autoscaling:
+      enabled: false
+  master:
+    resources:
+      limits:
+        cpu: 250m
+        memory: 512Mi
+      requests:
+        cpu: 50m
+        memory: 256Mi
+

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -64,3 +64,8 @@ silta-release:
 
 varnish:
   enabled: true
+
+redis:
+  enabled: false
+  auth:
+    password: "foo"


### PR DESCRIPTION
This setup mirrors what is available with the drupal chart, only using the latest version of the redis bitnami chart.


I have done these same changes for the `next-drupal-starterkit` using a local branch, and there I seem to be able to connect to redis from node, using multiple pods: https://github.com/wunderio/next-drupal-starterkit/pull/182 

> There were some issues in using this together with the mongodb chart, but now that https://github.com/wunderio/frontend-project-k8s/pull/116 has been merged, we should be able to continue the review.
