### PR TITLE
Mapping var, server block for proxy auth header

### DIFF
--- a/charts/frontend/templates/configmap.yaml
+++ b/charts/frontend/templates/configmap.yaml
@@ -102,6 +102,10 @@ data:
 
       # List health checks that need to return status 200 here
       map $http_user_agent $hc_ua { default 0; 'GoogleHC/1.0' 1; 'Varnish' 1; }
+      {{- if ne .Values.nginx.x_proxy_auth "" }}
+      # Verify if x_proxy_auth value is correct
+      map $http_x_proxy_auth $proxy_auth { default 0; '{{ .Values.nginx.x_proxy_auth }}' 1; }
+      {{- end}}
 
       include conf.d/*.conf;
     }
@@ -141,6 +145,10 @@ data:
 
       # Loadbalancer health checks need to be fed with http 200
       if ($hc_ua) { return 200; }
+      {{- if ne .Values.nginx.x_proxy_auth "" }}
+      # Block request if proxy header is set but does not match required value
+      if ($proxy_auth = 0) { return 403; }
+      {{- end}}
 
       {{- if .Values.nginx.redirects }}
       # Redirects to specified path if map returns anything
@@ -199,11 +207,6 @@ data:
       {{- range $index, $service := .Values.services }}
       {{- if $service.exposedRoute }}
       location {{ $service.exposedRoute }} {
-
-        {{- if ne $.Values.nginx.x_proxy_auth "" }}
-        # Verify if x_proxy_auth value is correct
-        if ( $http_x_proxy_auth != '{{ $.Values.nginx.x_proxy_auth }}') { return 403; }
-        {{- end}}
 
         {{- if $.Values.nginx.extra_conditions }}
         {{- $.Values.nginx.extra_conditions | nindent 8 }}


### PR DESCRIPTION
Previous approach allowed to bypass header from CDN in some paths. 
Test environment is created under 
feature/xproxyauth branch
Hostname: 
frontend-k8s-staging.fastly.wdr.io

You can wake it up and check direct URL with
`silta ci release wakeup --namespace frontend-project-k8s --release-name feature-xproxyauth`