### PR TITLE
Add lifecycle config with default 5s prestop for frontend services

### DIFF
--- a/charts/frontend/templates/services-deployment.yaml
+++ b/charts/frontend/templates/services-deployment.yaml
@@ -50,6 +50,14 @@ spec:
           - name: shell-keys
             mountPath: /etc/ssh/keys
           {{- end }}
+        lifecycle:
+        {{- if $service.lifecycle }}
+        {{- toYaml $service.lifecycle | nindent 10 }}
+        {{- else }}
+          lifecycle:
+            exec:
+              command: ["/bin/sleep", "5"]
+        {{- end }}
         livenessProbe:
         {{- if $service.livenessProbe }}
         {{- toYaml $service.livenessProbe | nindent 10 }}

--- a/charts/frontend/templates/services-deployment.yaml
+++ b/charts/frontend/templates/services-deployment.yaml
@@ -50,13 +50,9 @@ spec:
           - name: shell-keys
             mountPath: /etc/ssh/keys
           {{- end }}
-        lifecycle:
         {{- if $service.lifecycle }}
+        lifecycle:
         {{- toYaml $service.lifecycle | nindent 10 }}
-        {{- else }}
-          lifecycle:
-            exec:
-              command: ["/bin/sleep", "5"]
         {{- end }}
         livenessProbe:
         {{- if $service.livenessProbe }}

--- a/charts/frontend/values.schema.json
+++ b/charts/frontend/values.schema.json
@@ -207,6 +207,7 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
+              "postStart": { "type": "object" },
               "preStop": { "type": "object" }
             }
           },

--- a/charts/frontend/values.schema.json
+++ b/charts/frontend/values.schema.json
@@ -203,6 +203,13 @@
           "exposedRoute": { "type": "string" },
           "replicas": { "type": "integer" },
           "mounts": { "type": "array" },
+          "lifecycle": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "preStop": { "type": "object" }
+            }
+          },
           "readinessProbe": { "type": "object" },
           "livenessProbe": { "type": "object" },
           "strategy": { "type": "object" },

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -28,13 +28,10 @@ services:
     lifecycle:
       postStart:
         exec:
-          command: |
-            echo "Hello container is starting"
+          command: ['/bin/sh', '-c', 'echo "Hello container is starting" > /usr/share/message']
       preStop:
         exec:
-          command: |
-            echo "Hello container is shutting down"
-            /bin/sleep 5
+          command: ['/bin/sh', '-c', 'echo "Hello container is shutting down" > /usr/share/message; /bin/sleep 5']
     postinstall:
       command: |
         echo Postinstall command executed

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -24,6 +24,13 @@ services:
       tcpSocket:
         port: 4000
       initialDelaySeconds: 30
+    # Overridden lifecycle hook.
+    lifecycle:
+      preStop:
+        exec:
+          command: |
+            echo "Hello container is shutting down"
+            /bin/sleep 5
     postinstall:
       command: |
         echo Postinstall command executed

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -26,6 +26,10 @@ services:
       initialDelaySeconds: 30
     # Overridden lifecycle hook.
     lifecycle:
+      postStart:
+        exec:
+          command: |
+            echo "Hello container is starting"
       preStop:
         exec:
           command: |


### PR DESCRIPTION
We have an issue where we've seen that we've sent half css/js files to cloudflare, possibly related to deployments. 

I'm clutching at straws but I have a hunch that it may be caused by nextjs node containers being killed in the middle of transferring files to nginx (which passes them over to cloudflare). Allowing us to configure preStop hooks might help us avoid this issue.

Note: Keep in mind that I don't *really* know what I'm doing when reviewing.
