### PR TITLE
Remove redundant mongodb auth by default

### DIFF
--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -485,6 +485,8 @@ mongodb:
   initdbScripts:
     setFeatureCompatibilityVersion.js: |
       db.adminCommand({ setFeatureCompatibilityVersion: "6.0" });
+  auth:
+    enabled: false
   updateStrategy:
     type: Recreate
   enableServiceLinks: false


### PR DESCRIPTION
Removes requirement to set root password for mongodb instance