### PR TITLE
Adds robots header for location scope; adds header for non-200 pages

### DIFF
--- a/charts/frontend/templates/configmap.yaml
+++ b/charts/frontend/templates/configmap.yaml
@@ -94,8 +94,8 @@ data:
           {{- end }}
           default  '';
       }
-      add_header                  X-Robots-Tag $x_robots_tag_header;
-
+      add_header X-Robots-Tag $x_robots_tag_header always;
+      
       map $uri $no_slash_uri {
           ~^/(?<no_slash>.*)$ $no_slash;
       }
@@ -207,6 +207,8 @@ data:
       {{- range $index, $service := .Values.services }}
       {{- if $service.exposedRoute }}
       location {{ $service.exposedRoute }} {
+
+        add_header X-Robots-Tag $x_robots_tag_header always;
 
         {{- if $.Values.nginx.extra_conditions }}
         {{- $.Values.nginx.extra_conditions | nindent 8 }}


### PR DESCRIPTION
- adds robots header for location scope as there are other [add_header](http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header) directives.
> There could be several add_header directives. These directives are inherited from the previous configuration level if and only if there are no add_header directives defined on the current level. 
- adds header for non-200 pages