### PR TITLE
SLT-1040: Update default nginx version to 1.26.

### DIFF
--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -109,7 +109,7 @@ singleSubdomain: false
 
 # These variables are build-specific and should be passed via the --set parameter.
 nginx:
-  image: 'wunderio/silta-nginx:1.24-v1'
+  image: 'wunderio/silta-nginx:1.26-v1'
 
   # Requires "X-Proxy-Auth" header from upstream when value is non-empty string.
   x_proxy_auth: ""


### PR DESCRIPTION
### !! Blocked by https://github.com/wunderio/silta-images/pull/214 !!

Link to ticket: https://wunder.atlassian.net/browse/SLT-1040

Proposed changes:
- Update default nginx version to 1.26