### PR TITLE
allow injecting custom snippet in service location;  allow disabling dotfile blocking

### DIFF
--- a/charts/frontend/templates/configmap.yaml
+++ b/charts/frontend/templates/configmap.yaml
@@ -219,6 +219,11 @@ data:
         {{- tpl $.Values.nginx.locationExtraConfig $ | nindent 8 }}
         {{- end }}
 
+        # Service specific configuration
+        {{- if ($service.nginx).locationExtraConfig }}
+        {{- tpl $service.nginx.locationExtraConfig $ | nindent 8 }}
+        {{- end }}
+
         {{- include "frontend.basicauth" $ | trim | nindent 8 }}
 
         location = {{ $service.exposedRoute }}/robots.txt {
@@ -239,7 +244,9 @@ data:
 
         ## Rather than just denying .ht* in the config, why not deny
         ## access to all .invisible files
+        {{- if (mergeOverwrite $.Values.serviceDefaults.nginx ($service.nginx)).denyDotFiles }}
         location ~ /\. { return 404; access_log off; log_not_found off; }
+        {{- end }}
 
         # Pass the request on to frontend.
         proxy_pass http://{{ $.Release.Name }}-{{ $index }}:{{ default $.Values.serviceDefaults.port $service.port }}{{ $service.exposedRoute }};

--- a/charts/frontend/values.schema.json
+++ b/charts/frontend/values.schema.json
@@ -258,6 +258,14 @@
               "command": { "type": "string" }
             }
           },
+          "nginx": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "denyDotFiles": { "type": "boolean" },
+              "locationExtraConfig": { "type": "string" }
+            }
+          },
           "cron": {
             "type": "object",
             "additionalProperties": {
@@ -311,6 +319,13 @@
       "additionalProperties": false,
       "properties": {
         "port": { "type": "integer" },
+        "nginx": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "denyDotFiles": { "type": "boolean" }
+          }
+        },
         "resources": {
           "type": "object",
           "additionalProperties": false,

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -264,6 +264,12 @@ services: {}
   #   nodeSelector:
   #     cloud.google.com/gke-nodepool: static-ip
 
+  #  nginx:
+  #    denyDotFiles: true
+  #    locationExtraConfig: |
+  #      # Custom nginx for location block of this service
+
+
 # Configure the dynamically mounted volumes
 mounts: {}
 #  files:
@@ -320,6 +326,9 @@ backup:
 # Note that only keys used here can be overridden.
 serviceDefaults:
   port: 3000
+  nginx:
+    # Deny access to .dotfiles by default.
+    denyDotFiles: true
   resources:
     requests:
       cpu: 2m


### PR DESCRIPTION
PR proposes following changes:
- allows removing .dotfile rule that denies access to them;
- a service specific nginx configuration snippet that is added only to service location.