### PR TITLE
conditional persistentvolume creation

### DIFF
--- a/charts/frontend/templates/_helpers.tpl
+++ b/charts/frontend/templates/_helpers.tpl
@@ -232,3 +232,9 @@ autoscaling/v2
 autoscaling/v2beta1
 {{- end }}
 {{- end }}
+
+{{- define "silta-cluster.rclone.has-provisioner" }}
+{{- if ( $.Capabilities.APIVersions.Has "silta.wdr.io/v1" ) }}true
+{{- else }}false
+{{- end }}
+{{- end }}

--- a/charts/frontend/templates/backup-cron.yaml
+++ b/charts/frontend/templates/backup-cron.yaml
@@ -136,12 +136,20 @@ spec:
             {{- if eq $mount.enabled true }}
             - name: frontend-{{ $mountName }}
               persistentVolumeClaim:
+                {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+                claimName: {{ $.Release.Name }}-{{ $mountName }}2
+                {{- else }}
                 claimName: {{ $.Release.Name }}-{{ $mountName }}
+                {{- end }}
             {{- end }}
             {{- end }}
             {{- end }}
             {{- end }}
             - name: {{ .Release.Name }}-backup
               persistentVolumeClaim:
+                {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+                claimName: {{ .Release.Name }}-backup2
+                {{- else }}
                 claimName: {{ .Release.Name }}-backup
+                {{- end }}
 {{- end }}

--- a/charts/frontend/templates/backup-cron.yaml
+++ b/charts/frontend/templates/backup-cron.yaml
@@ -136,7 +136,7 @@ spec:
             {{- if eq $mount.enabled true }}
             - name: frontend-{{ $mountName }}
               persistentVolumeClaim:
-                {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+                {{- if and ( eq $mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
                 claimName: {{ $.Release.Name }}-{{ $mountName }}2
                 {{- else }}
                 claimName: {{ $.Release.Name }}-{{ $mountName }}
@@ -147,7 +147,7 @@ spec:
             {{- end }}
             - name: {{ .Release.Name }}-backup
               persistentVolumeClaim:
-                {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+                {{- if and ( eq $.Values.backup.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
                 claimName: {{ .Release.Name }}-backup2
                 {{- else }}
                 claimName: {{ .Release.Name }}-backup

--- a/charts/frontend/templates/backup-volume.yaml
+++ b/charts/frontend/templates/backup-volume.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.backup.enabled }}
+{{- if eq .Values.backup.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" . ) "false" }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -20,10 +22,16 @@ spec:
       remotePathSuffix: /{{ .Release.Namespace }}/backup/{{ .Values.environmentName }}
   {{- end }}
 ---
+{{- end }}
+{{- end }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  {{- if eq ( include "silta-cluster.rclone.has-provisioner" . ) "true" }}
+  name: {{ .Release.Name }}-backup2
+  {{- else }}
   name: {{ .Release.Name }}-backup
+  {{- end }}
   labels:
     name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backup
     {{- include "frontend.release_labels" $ | nindent 4 }}
@@ -37,8 +45,10 @@ spec:
     requests:
       storage: {{ .Values.backup.storage }}
 {{- if eq .Values.backup.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" . ) "false" }}
   selector:
     matchLabels:
       name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backup
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/frontend/templates/backup-volume.yaml
+++ b/charts/frontend/templates/backup-volume.yaml
@@ -27,7 +27,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  {{- if eq ( include "silta-cluster.rclone.has-provisioner" . ) "true" }}
+  {{- if and ( eq $.Values.backup.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
   name: {{ .Release.Name }}-backup2
   {{- else }}
   name: {{ .Release.Name }}-backup

--- a/charts/frontend/templates/services-cron.yaml
+++ b/charts/frontend/templates/services-cron.yaml
@@ -91,7 +91,7 @@ spec:
             {{- if eq $mount.enabled true }}
             - name: frontend-{{ $mountName }}
               persistentVolumeClaim:
-                {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+                {{- if and ( eq $mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
                 claimName: {{ $.Release.Name }}-{{ $mountName }}2
                 {{- else }}
                 claimName: {{ $.Release.Name }}-{{ $mountName }}

--- a/charts/frontend/templates/services-cron.yaml
+++ b/charts/frontend/templates/services-cron.yaml
@@ -91,7 +91,11 @@ spec:
             {{- if eq $mount.enabled true }}
             - name: frontend-{{ $mountName }}
               persistentVolumeClaim:
+                {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+                claimName: {{ $.Release.Name }}-{{ $mountName }}2
+                {{- else }}
                 claimName: {{ $.Release.Name }}-{{ $mountName }}
+                {{- end }}
             {{- end }}
             {{- end }}
             {{- end }}

--- a/charts/frontend/templates/services-deployment.yaml
+++ b/charts/frontend/templates/services-deployment.yaml
@@ -98,7 +98,11 @@ spec:
             name: {{ $mount.configMapName }}
         {{- else }}
           persistentVolumeClaim:
+            {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+            claimName: {{ $.Release.Name }}-{{ $mountName }}2
+            {{- else }}
             claimName: {{ $.Release.Name }}-{{ $mountName }}
+            {{- end }}
         {{- end }}
         {{- end }}
         {{- end }}
@@ -106,7 +110,11 @@ spec:
         {{ if $.Values.shell.enabled -}}
         - name: shell-keys
           persistentVolumeClaim:
+            {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+            claimName: {{ $.Release.Name }}-shell-keys2
+            {{- else }}
             claimName: {{ $.Release.Name }}-shell-keys
+            {{- end }}
         {{- end }}
       {{ if $service.nodeSelector -}}
       nodeSelector:
@@ -236,7 +244,11 @@ spec:
             name: {{ $mount.configMapName }}
         {{- else }}
           persistentVolumeClaim:
+            {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+            claimName: {{ $.Release.Name }}-{{ $mountName }}2
+            {{- else }}
             claimName: {{ $.Release.Name }}-{{ $mountName }}
+            {{- end }}
         {{- end }}
         {{- end }}
         {{- end }}
@@ -244,7 +256,11 @@ spec:
         {{ if $.Values.shell.enabled -}}
         - name: shell-keys
           persistentVolumeClaim:
+            {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+            claimName: {{ $.Release.Name }}-shell-keys2
+            {{- else }}
             claimName: {{ $.Release.Name }}-shell-keys
+            {{- end }}
         {{- end }}
 {{- end }}
 

--- a/charts/frontend/templates/services-deployment.yaml
+++ b/charts/frontend/templates/services-deployment.yaml
@@ -98,7 +98,7 @@ spec:
             name: {{ $mount.configMapName }}
         {{- else }}
           persistentVolumeClaim:
-            {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+            {{- if and ( eq $mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
             claimName: {{ $.Release.Name }}-{{ $mountName }}2
             {{- else }}
             claimName: {{ $.Release.Name }}-{{ $mountName }}
@@ -110,7 +110,7 @@ spec:
         {{ if $.Values.shell.enabled -}}
         - name: shell-keys
           persistentVolumeClaim:
-            {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+            {{- if and ( eq $.Values.shell.mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
             claimName: {{ $.Release.Name }}-shell-keys2
             {{- else }}
             claimName: {{ $.Release.Name }}-shell-keys
@@ -244,7 +244,7 @@ spec:
             name: {{ $mount.configMapName }}
         {{- else }}
           persistentVolumeClaim:
-            {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+            {{- if and ( eq $mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
             claimName: {{ $.Release.Name }}-{{ $mountName }}2
             {{- else }}
             claimName: {{ $.Release.Name }}-{{ $mountName }}
@@ -256,7 +256,7 @@ spec:
         {{ if $.Values.shell.enabled -}}
         - name: shell-keys
           persistentVolumeClaim:
-            {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+            {{- if and ( eq $.Values.shell.mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
             claimName: {{ $.Release.Name }}-shell-keys2
             {{- else }}
             claimName: {{ $.Release.Name }}-shell-keys

--- a/charts/frontend/templates/volumes.yaml
+++ b/charts/frontend/templates/volumes.yaml
@@ -2,6 +2,7 @@
 {{- if $mount.enabled }}
 {{- if and (not (hasKey $mount "configMapName")) (not (hasKey $mount "secretName")) -}}
 {{- if eq $mount.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
 # Mount-enabled: {{ $mount.enabled  }}
 apiVersion: v1
 kind: PersistentVolume
@@ -24,10 +25,15 @@ spec:
   {{- end }}
 ---
 {{- end }}
+{{- end }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+  name: {{ $.Release.Name }}-{{ $index }}2
+  {{- else }}
   name: {{ $.Release.Name }}-{{ $index }}
+  {{- end }}
   labels:
     {{- include "frontend.release_labels" $ | nindent 4 }}
   annotations:
@@ -40,9 +46,11 @@ spec:
     requests:
       storage: {{ $mount.storage }}
 {{- if eq $mount.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
   selector:
     matchLabels:
       name: {{ $.Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-{{ $index }}
+{{- end }}
 {{- end }}
 ---
 {{- end -}}
@@ -51,6 +59,7 @@ spec:
 
 {{- if $.Values.shell.enabled }}
 {{- if eq $.Values.shell.mount.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -72,15 +81,21 @@ spec:
       umask: "077"
   {{- end }}
 {{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+  name: {{ $.Release.Name }}-shell-keys2
+  {{- else }}
   name: {{ $.Release.Name }}-shell-keys
+  {{- end }}
   labels:
     {{- include "frontend.release_labels" $ | nindent 4 }}
   annotations:
     storage.silta/storage-path: {{ $.Values.environmentName | default $.Release.Name }}/shell-keys
+    csi-rclone/umask: "077"
 spec:
   storageClassName: {{ $.Values.shell.mount.storageClassName }}
   accessModes:
@@ -89,9 +104,11 @@ spec:
     requests:
       storage: 50M
 {{- if eq $.Values.shell.mount.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
   selector:
     matchLabels:
       name: {{ $.Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-shell-keys
+{{- end }}
 {{- end }}
 ---
 {{- end }}

--- a/charts/frontend/templates/volumes.yaml
+++ b/charts/frontend/templates/volumes.yaml
@@ -29,7 +29,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+  {{- if and ( eq $mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
   name: {{ $.Release.Name }}-{{ $index }}2
   {{- else }}
   name: {{ $.Release.Name }}-{{ $index }}
@@ -86,7 +86,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+  {{- if and ( eq $.Values.shell.mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
   name: {{ $.Release.Name }}-shell-keys2
   {{- else }}
   name: {{ $.Release.Name }}-shell-keys

--- a/charts/frontend/tests/volumes_test.yaml
+++ b/charts/frontend/tests/volumes_test.yaml
@@ -1,6 +1,7 @@
 suite: Data volumes
 templates:
   - volumes.yaml
+  - backup-volume.yaml
 tests:
   - it: public files volume should be configurable
     template: volumes.yaml
@@ -20,3 +21,163 @@ tests:
         equal:
           path: spec.resources.requests.storage
           value: 123Gi
+  
+  - it: backup pv creation when provisioner is unavailable
+    template: backup-volume.yaml
+    set:
+      backup:
+        enabled: true
+        storage: 123Gi
+        storageClassName: silta-shared
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: PersistentVolume
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-b6b6854-backup
+      - documentIndex: 1
+        equal:
+          path: kind
+          value: PersistentVolumeClaim
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-backup
+      - documentIndex: 1
+        exists:
+          path: spec.selector
+      - documentIndex: 1
+        equal:
+          path: spec.selector.matchLabels.name
+          value: RELEASE-NAME-b6b6854-backup
+  - it: backup pv creation when provisioner is available
+    template: backup-volume.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      backup:
+        enabled: true
+        storage: 123Gi
+        storageClassName: silta-shared
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: PersistentVolumeClaim
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-backup2
+      - documentIndex: 0
+        notExists:
+          path: spec.selector
+  - it: shell key pv creation when provisioner is not available
+    template: volumes.yaml
+    set:
+      shell:
+        enabled: true
+        mount:
+          storageClassName: silta-shared
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: PersistentVolume
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-b6b6854-shell-keys
+      - documentIndex: 1
+        equal:
+          path: kind
+          value: PersistentVolumeClaim
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-shell-keys
+      - documentIndex: 1
+        exists:
+          path: spec.selector
+      - documentIndex: 1
+        equal:
+          path: spec.selector.matchLabels.name
+          value: RELEASE-NAME-b6b6854-shell-keys
+  - it: shell key pv creation when provisioner is available
+    template: volumes.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      shell:
+        enabled: true
+        mount:
+          storageClassName: silta-shared
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: PersistentVolumeClaim
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-shell-keys2
+      - documentIndex: 0
+        notExists:
+          path: spec.selector
+  - it: custom mount pv creation when provisioner is not available
+    template: volumes.yaml
+    set:
+      mounts:
+        foo:
+          enabled: true
+          storageClassName: silta-shared
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: PersistentVolume
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-b6b6854-foo
+      - documentIndex: 1
+        equal:
+          path: kind
+          value: PersistentVolumeClaim
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-foo
+      - documentIndex: 1
+        exists:
+          path: spec.selector
+      - documentIndex: 1
+        equal:
+          path: spec.selector.matchLabels.name
+          value: RELEASE-NAME-b6b6854-foo
+  - it: custom mount pv creation when provisioner is available
+    template: volumes.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      mounts:
+        foo:
+          enabled: true
+          storageClassName: silta-shared
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: PersistentVolumeClaim
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-foo2
+      - documentIndex: 0
+        notExists:
+          path: spec.selector

--- a/charts/frontend/tests/volumes_test.yaml
+++ b/charts/frontend/tests/volumes_test.yaml
@@ -22,7 +22,7 @@ tests:
           path: spec.resources.requests.storage
           value: 123Gi
   
-  - it: backup pv creation when provisioner is unavailable
+  - it: backup pv creation when csi-rclone provisioner is unavailable
     template: backup-volume.yaml
     set:
       backup:
@@ -53,7 +53,7 @@ tests:
         equal:
           path: spec.selector.matchLabels.name
           value: RELEASE-NAME-b6b6854-backup
-  - it: backup pv creation when provisioner is available
+  - it: backup pv creation when csi-rclone provisioner is available (silta-shared storage class)
     template: backup-volume.yaml
     capabilities:
       apiVersions:
@@ -75,7 +75,29 @@ tests:
       - documentIndex: 0
         notExists:
           path: spec.selector
-  - it: shell key pv creation when provisioner is not available
+  - it: backup pv creation when csi-rclone provisioner is available (non-silta-shared storage class)
+    template: backup-volume.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      backup:
+        enabled: true
+        storage: 123Gi
+        storageClassName: foo
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: PersistentVolumeClaim
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-backup
+      - documentIndex: 0
+        notExists:
+          path: spec.selector
+  - it: shell key pv creation when csi-rclone provisioner is not available
     template: volumes.yaml
     set:
       shell:
@@ -106,7 +128,7 @@ tests:
         equal:
           path: spec.selector.matchLabels.name
           value: RELEASE-NAME-b6b6854-shell-keys
-  - it: shell key pv creation when provisioner is available
+  - it: shell key pv creation when csi-rclone provisioner is available (silta-shared storage class)
     template: volumes.yaml
     capabilities:
       apiVersions:
@@ -128,7 +150,29 @@ tests:
       - documentIndex: 0
         notExists:
           path: spec.selector
-  - it: custom mount pv creation when provisioner is not available
+  - it: shell key pv creation when csi-rclone provisioner is available (non-silta-shared storage class)
+    template: volumes.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      shell:
+        enabled: true
+        mount:
+          storageClassName: foo
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: PersistentVolumeClaim
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-shell-keys
+      - documentIndex: 0
+        notExists:
+          path: spec.selector
+  - it: custom mount pv creation when csi-rclone provisioner is not available
     template: volumes.yaml
     set:
       mounts:
@@ -159,7 +203,7 @@ tests:
         equal:
           path: spec.selector.matchLabels.name
           value: RELEASE-NAME-b6b6854-foo
-  - it: custom mount pv creation when provisioner is available
+  - it: custom mount pv creation when csi-rclone provisioner is available (silta-shared storage class)
     template: volumes.yaml
     capabilities:
       apiVersions:
@@ -178,6 +222,28 @@ tests:
         equal:
           path: metadata.name
           value: RELEASE-NAME-foo2
+      - documentIndex: 0
+        notExists:
+          path: spec.selector
+  - it: custom mount pv creation when csi-rclone provisioner is available (non-silta-shared storage class)
+    template: volumes.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      mounts:
+        foo:
+          enabled: true
+          storageClassName: foo
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: PersistentVolumeClaim
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-foo
       - documentIndex: 0
         notExists:
           path: spec.selector


### PR DESCRIPTION
Changes:
- Skips silta-shared PV creation when provisioner is available, removes selector field from silta-shared PVC's
- PVC name change for silta-shared storageclass PVC's to avoid immutable field update errors

Testing:
a1: Make a new branch off master, add mounts section, use it in service and deploy it to cluster with updated storage driver.
a2: Store some files
a3: Merge this branch into it, deploy, see if files are still present. PVC name should end with "2"

b1: Make a new branch off master, add mounts section, change storageclass to something else, deploy it to cluster with updated storage driver.
b2: Store some files
b3: Merge this branch into it, see if files are still present. Validate PVC name, it should not end with "2"

Do the same on a cluster without csi rclone update, PVC names in both cases should be without "2" at the end.