### PR TITLE
Update silta.yml

### DIFF
--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -75,6 +75,9 @@ varnish:
 
 redis:
   enabled: false
+#Setting the value false by default as it is causing slowdown on namespaces with lot of environment variables.
+  master:
+    enableServiceLinks: false  
   auth:
     password: "foo"
     


### PR DESCRIPTION
Setting  enableServiceLinks: false  by default due to performance issues on namespaces with lot of environment values.