### PR TITLE
extraConfig mount fix

### DIFF
--- a/charts/frontend/templates/nginx.yaml
+++ b/charts/frontend/templates/nginx.yaml
@@ -114,6 +114,10 @@ spec:
               - key: nginx_signalsciences_conf
                 path: nginx_signalsciences_conf
               {{- end }}
+              {{- if .Values.nginx.extraConfig }}
+              - key: extraConfig
+                path: extraConfig
+              {{- end }}
         {{- if .Values.nginx.basicauth.enabled }}
         - name: nginx-basicauth
           secret:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -5,6 +5,11 @@
 # for all possible options.
 
 nginx:
+  extraConfig: |
+    map $http_upgrade $connection_upgrade {
+      default upgrade;
+      '' close;
+    }
   redirects:
     - description: 'Redirect main path to default service (exact match)'
       from: ""

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -5,11 +5,6 @@
 # for all possible options.
 
 nginx:
-  extraConfig: |
-    map $http_upgrade $connection_upgrade {
-      default upgrade;
-      '' close;
-    }
   redirects:
     - description: 'Redirect main path to default service (exact match)'
       from: ""


### PR DESCRIPTION
Fixes `extraConfig` mount. Nginx failed to start with error when extraConfig was defined:
> [crit] 1#1: pread() "/etc/nginx/conf.d/misc.conf" failed (21: Is a directory)

```  
nginx:
  extraConfig: |
    # test
```