### PR TITLE
SLT-1103: Frontend chart: Add support for mailpit, deprecate mailhog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ workflows:
                 name: Add helm repositories and build local chart
                 command: |
                   helm repo add elastic https://helm.elastic.co
+                  helm repo add jouve https://jouve.github.io/charts/
                   helm repo add codecentric https://codecentric.github.io/helm-charts
                   helm dependency build ./charts/frontend
             - run:

--- a/charts/frontend/Chart.lock
+++ b/charts/frontend/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 5.1.0
 - name: mailpit
   repository: https://jouve.github.io/charts/
-  version: 0.23.1
+  version: 0.24.0
 - name: elasticsearch
   repository: file://../elasticsearch
   version: 8.5.1
@@ -26,5 +26,5 @@ dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 19.1.5
-digest: sha256:98141819adde164325215c348bfa871d7cbfdacbcbc3effd53bfe0b051c2f698
-generated: "2025-04-02T15:21:37.735374+03:00"
+digest: sha256:6d8a9d224e4f05d80001444956b411ec09e584c90894d897ebf0f4d7d275d7f9
+generated: "2025-04-08T22:49:11.202227+03:00"

--- a/charts/frontend/Chart.lock
+++ b/charts/frontend/Chart.lock
@@ -5,6 +5,9 @@ dependencies:
 - name: mailhog
   repository: https://storage.googleapis.com/charts.wdr.io
   version: 5.1.0
+- name: mailpit
+  repository: https://jouve.github.io/charts/
+  version: 0.23.1
 - name: elasticsearch
   repository: file://../elasticsearch
   version: 8.5.1
@@ -23,5 +26,5 @@ dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 19.1.5
-digest: sha256:b5bdf0a7bd385f79ea727101d2fa5b02859e027fc2f1408d0e711d604132d476
-generated: "2025-03-18T10:38:55.608016594+02:00"
+digest: sha256:98141819adde164325215c348bfa871d7cbfdacbcbc3effd53bfe0b051c2f698
+generated: "2025-04-02T15:21:37.735374+03:00"

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
   repository: https://storage.googleapis.com/charts.wdr.io
   condition: mailhog.enabled
 - name: mailpit
-  version: 0.23.x
+  version: 0.24.x
   repository: https://jouve.github.io/charts/
   condition: mailpit.enabled
 - name: elasticsearch

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -10,6 +10,10 @@ dependencies:
   version: 5.1.x
   repository: https://storage.googleapis.com/charts.wdr.io
   condition: mailhog.enabled
+- name: mailpit
+  version: 0.23.x
+  repository: https://jouve.github.io/charts/
+  condition: mailpit.enabled
 - name: elasticsearch
   version: 8.5.x
   # repository: https://helm.elastic.co

--- a/charts/frontend/templates/NOTES.txt
+++ b/charts/frontend/templates/NOTES.txt
@@ -29,6 +29,16 @@ Mailhog available at:
   {{- end }}
 {{- end }}
 
+{{- if .Values.mailpit.enabled }}
+
+Mailpit available at:
+
+  http://{{- template "frontend.domain" . }}/mailpit
+  {{- range $index, $domain := .Values.exposeDomains }}
+  http://{{ $domain.hostname }}/mailpit
+  {{- end }}
+{{- end }}
+
 {{ if $.Values.shell.enabled }}
 SSH connection (limited access through VPN):
   {{ range $index, $service := .Values.services }}

--- a/charts/frontend/templates/_helpers.tpl
+++ b/charts/frontend/templates/_helpers.tpl
@@ -182,6 +182,13 @@ rsync -az /values_mounts/ /backups/current/
 - name: MAILHOG_ADDRESS
   value: "{{ .Release.Name }}-mailhog:1025"
 {{- end }}
+{{- if .Values.mailpit.enabled }}
+{{- if contains "mailpit" .Release.Name -}}
+{{- fail "Do not use 'mailpit' in release name or deployment will fail" -}}
+{{- end }}
+- name: MAILPIT_ADDRESS
+  value: "{{ .Release.Name }}-mailpit-smtp:25"
+{{- end }}
 {{- if .Values.varnish.enabled }}
 - name: VARNISH_ADMIN_HOST
   value: {{ .Release.Name }}-varnish

--- a/charts/frontend/templates/checks.yaml
+++ b/charts/frontend/templates/checks.yaml
@@ -1,7 +1,13 @@
+{{- if and .Values.mailhog.enabled .Values.mailpit.enabled }}
+{{- fail "Mailhog and mailpit can't be enabled at the same time as those are overlapping services. Use mailpit only as mailhog is deprecated." -}}
+{{- end }}
 {{- if index (index .Values "silta-release") "branchName" }}
 {{- if eq (index (index .Values "silta-release") "branchName") "production" }}
 {{- if .Values.mailhog.enabled }}
 {{- fail "Mailhog should not be enabled in production" -}}
+{{- end }}
+{{- if .Values.mailpit.enabled }}
+{{- fail "Mailpit should not be enabled in production" -}}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/frontend/templates/configmap.yaml
+++ b/charts/frontend/templates/configmap.yaml
@@ -199,6 +199,43 @@ data:
       }
       {{- end}}
 
+      {{- if .Values.mailpit.enabled }}
+      # Redirect the legacy mailhog service to mailpit.
+      location /mailhog {
+        return 301 /mailpit/;
+      }
+      location /mailpit/ {
+                # Auth / whitelist always enabled
+        satisfy any;
+        allow 127.0.0.1;
+        {{- range .Values.nginx.noauthips }}
+        allow {{ . }};
+        {{- end }}
+        deny all;
+
+        {{- if gt (len .Values.nginx.noauthips) 1 -}}
+        # Basic auth only offered when at least one extra ip is whitelisted. Prevents using default credentials.
+        auth_basic "Restricted";
+        auth_basic_user_file /etc/nginx/.htaccess;
+        {{- end}}
+
+        # Proxy to mailpit container
+        proxy_pass http://{{ .Release.Name }}-mailpit-http:80/mailpit/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # Websock connection
+        chunked_transfer_encoding on;
+        proxy_set_header X-NginX-Proxy true;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_http_version 1.1;
+        proxy_redirect off;
+        proxy_buffering off;
+      }
+      {{- end}}
+
       # Custom configuration gets included here
       {{- if .Values.nginx.serverExtraConfig }}
       {{- tpl .Values.nginx.serverExtraConfig . | trim | nindent 6 }}

--- a/charts/frontend/templates/varnish-configmap-vcl.yaml
+++ b/charts/frontend/templates/varnish-configmap-vcl.yaml
@@ -138,6 +138,13 @@ data:
       }
       {{- end }}
 
+      {{- if .Values.mailpit.enabled }}
+      // No varnish for mailpit
+      if (req.url ~ "^/mailpit(/|$)") {
+        return (pass);
+      }
+      {{- end }}
+
       if (req.http.Accept-Encoding) {
         if (req.url ~ "\.(jpg|png|gif|svg|tif|tiff|ico|webp|gz|tgz|bz2|tbz|mp3|ogg|swf|zip|pdf|woff|eot|ttf)(\?.*)?$") {
           # No point in compressing these

--- a/charts/frontend/test.values.yaml
+++ b/charts/frontend/test.values.yaml
@@ -29,7 +29,7 @@ shell:
 elasticsearch:
   enabled: true
 
-mailhog:
+mailpit:
   enabled: true
 
 mongodb:

--- a/charts/frontend/values.schema.json
+++ b/charts/frontend/values.schema.json
@@ -582,6 +582,12 @@
         "enabled": { "type": "boolean" }
       }
     },
+    "mailpit": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
     "mailhog": {
       "type": "object",
       "properties": {

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -595,6 +595,7 @@ mailpit:
   mailpit:
     # This is for easier proxying from Drupal's nginx
     webroot: /mailpit
+  enableServiceLinks: false
 
 # Important! This service is deprecated and will be removed from future releases. Please use "mailpit" instead.
 # Mailhog service overrides

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -597,7 +597,6 @@ mailpit:
     webroot: /mailpit
 
 # Important! This service is deprecated and will be removed from future releases. Please use "mailpit" instead.
-
 # Mailhog service overrides
 # see: https://github.com/codecentric/helm-charts/blob/master/charts/mailhog/values.yaml
 mailhog:

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -576,6 +576,28 @@ signalsciences:
       cpu: 200m
       memory: 300Mi
 
+# Mailpit service overrides
+# see: https://github.com/jouve/charts/blob/main/charts/mailpit/values.yaml
+mailpit:
+  enabled: false
+  extraEnvVars:
+    - name: MP_SMTP_AUTH_ACCEPT_ANY
+      value: "true"
+    - name: MP_SMTP_AUTH_ALLOW_INSECURE
+      value: "true"
+  resources:
+    requests:
+      cpu: 1m
+      memory: 10M
+    limits:
+      cpu: 50m
+      memory: 100M
+  mailpit:
+    # This is for easier proxying from Drupal's nginx
+    webroot: /mailpit
+
+# Important! This service is deprecated and will be removed from future releases. Please use "mailpit" instead.
+
 # Mailhog service overrides
 # see: https://github.com/codecentric/helm-charts/blob/master/charts/mailhog/values.yaml
 mailhog:
@@ -590,9 +612,6 @@ mailhog:
     requests:
       cpu: 1m
       memory: 10M
-
-mailpit:
-  enabled: false
 
 # Redis
 # https://github.com/bitnami/charts/blob/master/bitnami/redis/values.yaml

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -591,6 +591,9 @@ mailhog:
       cpu: 1m
       memory: 10M
 
+mailpit:
+  enabled: false
+
 # Redis
 # https://github.com/bitnami/charts/blob/master/bitnami/redis/values.yaml
 redis:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -80,3 +80,6 @@ redis:
     
 mongodb:
   enabled: true
+
+mailpit:
+  enabled: true


### PR DESCRIPTION
**Motivation:**
[Mailhog](https://github.com/mailhog/MailHog) is an email service we’re using in our development environments (local & Silta non-production) to test out if email functionalities are working properly. Mailhog https://github.com/mailhog/MailHog/issues/442#issuecomment-1493415258 and is causing issues for developers. Therefore, we need to replace it with some alternative. Our current pick is [Mailpit](https://mailpit.axllent.org/).

**Changes proposed:**
- Add mailpit dependency, enable it, add default value overrides
- Update chart templates with needed changes for mailpit to work
- Keep mailhog in chart but add deprecation notices

**How to test:**
1. Install the updated chart and see that mailpit works (`helm install frontend-release charts/frontend --set mailpit.enabled=true` or test here: https://app.circleci.com/pipelines/github/wunderio/frontend-project-k8s/1544/workflows/1c038599-e79c-4987-8fd3-b3b47340c4c3). Test the following:
- validation goes through
- mailpit URL is listed in the release notes and it works
- the legacy /mailhog path redirects to /mailpit
- try sending an email from front-end, i.e., ssh into either `hello` or `world` pods run `printf "EHLO localhost\r\nMAIL FROM:<test@example.com>\r\nRCPT TO:<recipient@example.com>\r\nDATA\r\nSubject: Test Email\r\n\r\nThis is a test email.\r\n.\r\nQUIT\r\n" | nc $MAILPIT_ADDRESS 25`, see that the command is successful and there is a new e-mail in mailpit.
- Test that mailpit's UI works, i.e, you can mark emails as read, delete them, download etc.
2. See that updated installation checks work, i.e., try to install chart with both `mailpit` and `mailhog` enabled (i.e., run `helm install frontend-release charts/frontend --set mailpit.enabled=true --set mailhog.enabled=true --dry-run`), see that the installation fails.
