### PR TITLE
Security contexts

### DIFF
--- a/charts/frontend/templates/services-deployment.yaml
+++ b/charts/frontend/templates/services-deployment.yaml
@@ -29,13 +29,17 @@ spec:
         # We use a checksum to redeploy the pods when the configMap changes.
         configMap-checksum: {{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum }}
     spec:
+      {{- if $service.podSecurityContext }}
+      securityContext:
+        {{- toYaml $service.podSecurityContext | nindent 8 }}
+      {{- end }}
       enableServiceLinks: false
       containers:
       - name: {{ $index }}
         image: {{ $service.image | quote }}
-        {{- if $service.securityContext }}
+        {{- if $service.containerSecurityContext }}
         securityContext:
-          {{- toYaml $service.securityContext | nindent 10 }}
+          {{- toYaml $service.containerSecurityContext | nindent 10 }}
         {{- end }}
         ports:
         - containerPort: {{ default $.Values.serviceDefaults.port $service.port }}

--- a/charts/frontend/values.schema.json
+++ b/charts/frontend/values.schema.json
@@ -321,9 +321,67 @@
             "type": "object",
             "additionalProperties": { "type": "string" }
           },
-          "securityContext": {
+          "containerSecurityContext": {
             "type": "object",
             "additionalProperties": false,
+            "properties": {
+              "allowPrivilegeEscalation": { "type": "boolean" },
+              "readOnlyRootFilesystem": { "type": "boolean" },
+              "runAsNonRoot": { "type": "boolean" },
+              "runAsUser": { "type": "integer" },
+              "runAsGroup": { "type": "integer" },
+              "fsGroup": { "type": "integer" },
+              "privileged": { "type": "boolean" },
+              "procMount": { "type": "string" },
+              "capabilities": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "add": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "drop": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  }
+                }
+              },
+              "seccompProfile": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "type": { "type": "string" },
+                  "localhostProfile": { "type": "string" }
+                }
+              },
+              "seLinuxOptions": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "level": { "type": "string" },
+                  "role": { "type": "string" },
+                  "type": { "type": "string" },
+                  "user": { "type": "string" }
+                }
+              },
+              "sysctls": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": { "type": "string" },
+                    "value": { "type": "string" }
+                  },
+                  "required": ["name", "value"]
+                }
+              }
+            }
+          },
+          "podSecurityContext": {
+            "type": "object",
+            "additionalProperties": true,
             "properties": {
               "allowPrivilegeEscalation": { "type": "boolean" },
               "readOnlyRootFilesystem": { "type": "boolean" },

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -228,8 +228,10 @@ services: {}
   #   mounts:
   #     - files
   #
-  #   # Security context settings for this service
-  #   securityContext: {}
+  #   # Pod level security context settings for this service
+  #   podSecurityContext: {}
+  #   # Container level security context settings
+  #   containerSecurityContext: {}
 
   #   # Enable autoscaling using HorizontalPodAutoscaler
   #   # see: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -39,13 +39,13 @@ services:
       command: |
         echo Postupgrade command executed
     containerSecurityContext:
-      runAsUser: 0
-    podSecurityContext:
       capabilities:
         drop: 
         - ALL
         add:
         - NET_BIND_SERVICE
+    podSecurityContext:
+      runAsUser: 1000
 
   world:
     exposedRoute: '/world'

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -38,14 +38,6 @@ services:
     postupgrade:
       command: |
         echo Postupgrade command executed
-    containerSecurityContext:
-      capabilities:
-        drop: 
-        - ALL
-        add:
-        - NET_BIND_SERVICE
-    podSecurityContext:
-      runAsUser: 0
 
   world:
     exposedRoute: '/world'

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -45,7 +45,7 @@ services:
         add:
         - NET_BIND_SERVICE
     podSecurityContext:
-      runAsUser: 1000
+      runAsUser: 0
 
   world:
     exposedRoute: '/world'

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -38,6 +38,14 @@ services:
     postupgrade:
       command: |
         echo Postupgrade command executed
+    containerSecurityContext:
+      runAsUser: 0
+    podSecurityContext:
+      capabilities:
+        drop: 
+        - ALL
+        add:
+        - NET_BIND_SERVICE
 
   world:
     exposedRoute: '/world'


### PR DESCRIPTION
Differentiates between pod and container security contexts.

Use `podSecurityContext` variable to set PodSecurityContext object https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#podsecuritycontext-v1-core , such as `runAsUser` .
Use `containerSecurityContext` variable for SecurityContext object https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#securitycontext-v1-core , such as `capabilites`

Testing:
After setting podSecurityContext, containerSecurityContext on `hello` service, both context objects should be visible in `hello` pods definition after deployment.