### PR TITLE
SLT-1193: Frontend chart: Remove deprecated mailhog service from the chart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,6 @@ workflows:
                 command: |
                   helm repo add elastic https://helm.elastic.co
                   helm repo add jouve https://jouve.github.io/charts/
-                  helm repo add codecentric https://codecentric.github.io/helm-charts
                   helm dependency build ./charts/frontend
             - run:
                 name: Dry-run helm install
@@ -235,7 +234,7 @@ workflows:
                 name: Add helm repositories and build local chart
                 command: |
                   helm repo add elastic https://helm.elastic.co
-                  helm repo add codecentric https://codecentric.github.io/helm-charts
+                  helm repo add jouve https://jouve.github.io/charts/
                   helm dependency build ./charts/frontend
             - run:
                 name: Dry-run helm install

--- a/charts/frontend/Chart.lock
+++ b/charts/frontend/Chart.lock
@@ -2,9 +2,6 @@ dependencies:
 - name: mariadb
   repository: https://storage.googleapis.com/charts.wdr.io
   version: 7.10.4
-- name: mailhog
-  repository: https://storage.googleapis.com/charts.wdr.io
-  version: 5.1.0
 - name: mailpit
   repository: https://jouve.github.io/charts/
   version: 0.24.0
@@ -26,5 +23,5 @@ dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 19.1.5
-digest: sha256:6d8a9d224e4f05d80001444956b411ec09e584c90894d897ebf0f4d7d275d7f9
-generated: "2025-04-08T22:49:11.202227+03:00"
+digest: sha256:0b781b6165e8f06c146449246d449e79256ef51cf1ec2f2f5666ba81a90410e0
+generated: "2025-05-19T14:33:45.989869+03:00"

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -6,10 +6,6 @@ dependencies:
   version: 7.10.x
   repository: https://storage.googleapis.com/charts.wdr.io
   condition: mariadb.enabled
-- name: mailhog
-  version: 5.1.x
-  repository: https://storage.googleapis.com/charts.wdr.io
-  condition: mailhog.enabled
 - name: mailpit
   version: 0.24.x
   repository: https://jouve.github.io/charts/

--- a/charts/frontend/templates/NOTES.txt
+++ b/charts/frontend/templates/NOTES.txt
@@ -19,16 +19,6 @@ Deployed {{ .Release.Name }} successfully, your site is available here:
   Basicauth password: {{ .Values.nginx.basicauth.credentials.password }}
   {{- end }}
 
-{{- if .Values.mailhog.enabled }}
-  
-Mailhog available at:
-
-  http://{{- template "frontend.domain" . }}/mailhog
-  {{- range $index, $domain := .Values.exposeDomains }}
-  http://{{ $domain.hostname }}/mailhog
-  {{- end }}
-{{- end }}
-
 {{- if .Values.mailpit.enabled }}
 
 Mailpit available at:

--- a/charts/frontend/templates/_helpers.tpl
+++ b/charts/frontend/templates/_helpers.tpl
@@ -175,13 +175,6 @@ rsync -az /values_mounts/ /backups/current/
     fieldRef:
       fieldPath: status.hostIP
 {{- end }}
-{{- if .Values.mailhog.enabled }}
-{{- if contains "mailhog" .Release.Name -}}
-{{- fail "Do not use 'mailhog' in release name or deployment will fail" -}}
-{{- end }}
-- name: MAILHOG_ADDRESS
-  value: "{{ .Release.Name }}-mailhog:1025"
-{{- end }}
 {{- if .Values.mailpit.enabled }}
 {{- if contains "mailpit" .Release.Name -}}
 {{- fail "Do not use 'mailpit' in release name or deployment will fail" -}}

--- a/charts/frontend/templates/checks.yaml
+++ b/charts/frontend/templates/checks.yaml
@@ -1,11 +1,5 @@
-{{- if and .Values.mailhog.enabled .Values.mailpit.enabled }}
-{{- fail "Mailhog and mailpit can't be enabled at the same time as those are overlapping services. Use mailpit only as mailhog is deprecated." -}}
-{{- end }}
 {{- if index (index .Values "silta-release") "branchName" }}
 {{- if eq (index (index .Values "silta-release") "branchName") "production" }}
-{{- if .Values.mailhog.enabled }}
-{{- fail "Mailhog should not be enabled in production" -}}
-{{- end }}
 {{- if .Values.mailpit.enabled }}
 {{- fail "Mailpit should not be enabled in production" -}}
 {{- end }}

--- a/charts/frontend/templates/configmap.yaml
+++ b/charts/frontend/templates/configmap.yaml
@@ -165,40 +165,6 @@ data:
 
       include fastcgi.conf;
 
-      {{- if .Values.mailhog.enabled }}
-      location /mailhog {
-
-        # Auth / whitelist always enabled
-        satisfy any;
-        allow 127.0.0.1;
-        {{- range .Values.nginx.noauthips }}
-        allow {{ . }};
-        {{- end }}
-        deny all;
-
-        {{- if gt (len .Values.nginx.noauthips) 1 -}}
-        # Basic auth only offered when at least one extra ip is whitelisted. Prevents using default credentials.
-        auth_basic "Restricted";
-        auth_basic_user_file /etc/nginx/.htaccess;
-        {{- end}}
-
-        rewrite ^/mailhog$ /mailhog/ permanent;
-
-        # Proxy to mailhog container
-        rewrite /mailhog(.*) $1 break;
-        proxy_pass http://{{ .Release.Name }}-mailhog:8025/;
-
-        # Websock connection
-        chunked_transfer_encoding on;
-        proxy_set_header X-NginX-Proxy true;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_http_version 1.1;
-        proxy_redirect off;
-        proxy_buffering off;
-      }
-      {{- end}}
-
       {{- if .Values.mailpit.enabled }}
       # Redirect the legacy mailhog service to mailpit.
       location /mailhog {

--- a/charts/frontend/templates/varnish-configmap-vcl.yaml
+++ b/charts/frontend/templates/varnish-configmap-vcl.yaml
@@ -131,13 +131,6 @@ data:
         set req.hash_always_miss = true;
       }
 
-      {{- if .Values.mailhog.enabled }}
-      # No varnish for mailhog
-      if (req.url ~ "^/mailhog$") {
-        return (pass);
-      }
-      {{- end }}
-
       {{- if .Values.mailpit.enabled }}
       // No varnish for mailpit
       if (req.url ~ "^/mailpit(/|$)") {

--- a/charts/frontend/values.schema.json
+++ b/charts/frontend/values.schema.json
@@ -704,21 +704,6 @@
         "enabled": { "type": "boolean" }
       }
     },
-    "mailhog": {
-      "type": "object",
-      "properties": {
-        "enabled": { "type": "boolean" },
-        "image": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "repository": { "type": "string" },
-            "tag": { "type": "string" },
-            "pullPolicy": { "type": "string" }
-          }
-        }
-      }
-    },
     "silta-release": {
       "type": "object"
     },

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -602,22 +602,6 @@ mailpit:
     webroot: /mailpit
   enableServiceLinks: false
 
-# Important! This service is deprecated and will be removed from future releases. Please use "mailpit" instead.
-# Mailhog service overrides
-# see: https://github.com/codecentric/helm-charts/blob/master/charts/mailhog/values.yaml
-mailhog:
-  enabled: false
-  enableServiceLinks: false
-  image:
-    # Set image repository to "mailhog/mailhog" to reenable logging.
-    repository: wunderio/silta-mailhog
-    # Set image tag to "" to reenable logging.
-    tag: v1
-  resources:
-    requests:
-      cpu: 1m
-      memory: 10M
-
 # Redis
 # https://github.com/bitnami/charts/blob/master/bitnami/redis/values.yaml
 redis:


### PR DESCRIPTION
**Changes proposed:**
- Remove mailhog that was deprecated in #141 and replaced by mailpit, clean up chart from mailhog's configuration.

**How to test:**
- See that chart validation and deployment is green: https://app.circleci.com/pipelines/github/wunderio/frontend-project-k8s?branch=feature%2FSLT-1193-rm-mail
- See that mailpit still works and is available under frontend's /mailpit path.