### PR TITLE
Use last non-trusted address sent in the request header field

### DIFF
--- a/charts/frontend/templates/configmap.yaml
+++ b/charts/frontend/templates/configmap.yaml
@@ -44,6 +44,7 @@ data:
       {{- end }}
 
       real_ip_header              {{ .Values.nginx.real_ip_header }};
+      real_ip_recursive           on;
 
       include                     /etc/nginx/mime.types;
       default_type                application/octet-stream;


### PR DESCRIPTION
Trust IP's in `set_real_ip_from` list to supply correct `real_ip_header` value. 
This is already in drupal chart.
https://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive