### PR TITLE
SLT-1193: Add deprecation warning for mailhog in release notes

### DIFF
--- a/charts/frontend/templates/NOTES.txt
+++ b/charts/frontend/templates/NOTES.txt
@@ -27,6 +27,8 @@ Mailhog available at:
   {{- range $index, $domain := .Values.exposeDomains }}
   http://{{ $domain.hostname }}/mailhog
   {{- end }}
+  ⚠️ **DEPRECATED** mailhog is deprecated and will be removed in the future, use mailpit instead
+  See: https://wunderio.github.io/silta/docs/silta-examples#sending-e-mail
 {{- end }}
 
 {{- if .Values.mailpit.enabled }}


### PR DESCRIPTION
How to test:
 - See that there is a deprecation warning in release notes:
   - **option 1**: https://app.circleci.com/pipelines/github/wunderio/frontend-project-k8s/1599/workflows/c72f86d2-0bc3-4adb-b588-7289cd784ddc/jobs/4093?invite=true#step-127-289_21
   - **option 2**: Checkout this branch and run `helm install --dry-run test-frontend ./charts/frontend --set mailhog.enabled=true`