### PR TITLE
securityContext override for service cronjobs

### DIFF
--- a/charts/frontend/templates/services-cron.yaml
+++ b/charts/frontend/templates/services-cron.yaml
@@ -28,12 +28,24 @@ spec:
             cronjob: "true"
         spec:
           enableServiceLinks: false
+          {{- if or (hasKey $job "podSecurityContext") (hasKey $service "podSecurityContext") }}
+          securityContext:
+            {{- if hasKey $job "podSecurityContext" }}
+            {{- toYaml $job.podSecurityContext | nindent 12 }}
+            {{- else if hasKey $service "podSecurityContext" }}
+            {{- toYaml $service.podSecurityContext | nindent 12 }}
+            {{- end }}
+          {{- end }}
           containers:
           - name: {{ $jobName }}-cron
             image: {{ $service.image | quote }}
-            {{- if $service.securityContext }}
+            {{- if or (hasKey $job "containerSecurityContext") (hasKey $service "containerSecurityContext") }}
             securityContext:
-              {{- toYaml $service.securityContext | nindent 14 }}
+              {{- if hasKey $job "containerSecurityContext" }}
+              {{- toYaml $job.containerSecurityContext | nindent 14 }}
+              {{- else if hasKey $service "containerSecurityContext" }}
+              {{- toYaml $service.containerSecurityContext | nindent 14 }}
+              {{- end }}
             {{- end }}
             volumeMounts:
               {{- if $service.mounts }}

--- a/charts/frontend/tests/services-cron_test.yaml
+++ b/charts/frontend/tests/services-cron_test.yaml
@@ -196,3 +196,129 @@ tests:
           content:
             name: TZ
             value: Foo/Bar
+
+  - it: can set podSecurityContext at cron job level
+    template: services-cron.yaml
+    set:
+      services.foo:
+        image: 'bar'
+        cron:
+          foo:
+            command: echo "Hello world"
+            schedule: '1 2 3 * *'
+            podSecurityContext:
+              fsGroup: 1000
+              runAsUser: 1001
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.fsGroup
+          value: 1000
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.runAsUser
+          value: 1001
+
+  - it: can set containerSecurityContext at cron job level
+    template: services-cron.yaml
+    set:
+      services.foo:
+        image: 'bar'
+        cron:
+          foo:
+            command: echo "Hello world"
+            schedule: '1 2 3 * *'
+            containerSecurityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+
+  - it: inherits podSecurityContext from service level
+    template: services-cron.yaml
+    set:
+      services.foo:
+        image: 'bar'
+        podSecurityContext:
+          fsGroup: 2000
+          runAsUser: 2001
+        cron:
+          foo:
+            command: echo "Hello world"
+            schedule: '1 2 3 * *'
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.fsGroup
+          value: 2000
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.runAsUser
+          value: 2001
+
+  - it: inherits containerSecurityContext from service level
+    template: services-cron.yaml
+    set:
+      services.foo:
+        image: 'bar'
+        containerSecurityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+        cron:
+          foo:
+            command: echo "Hello world"
+            schedule: '1 2 3 * *'
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+
+  - it: cronjob level podSecurityContext takes precedence over service level podSecurityContext
+    template: services-cron.yaml
+    set:
+      services.foo:
+        image: 'bar'
+        podSecurityContext:
+          fsGroup: 2000
+          runAsUser: 2001
+        cron:
+          foo:
+            command: echo "Hello world"
+            schedule: '1 2 3 * *'
+            podSecurityContext:
+              fsGroup: 3000
+              runAsUser: 3001
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.fsGroup
+          value: 3000
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.runAsUser
+          value: 3001
+
+  - it: cronjob level containerSecurityContext takes precedence over service level containerSecurityContext
+    template: services-cron.yaml
+    set:
+      services.foo:
+        image: 'bar'
+        containerSecurityContext:
+          allowPrivilegeEscalation: true
+          readOnlyRootFilesystem: true
+        cron:
+          foo:
+            command: echo "Hello world"
+            schedule: '1 2 3 * *'
+            containerSecurityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: false

--- a/charts/frontend/values.schema.json
+++ b/charts/frontend/values.schema.json
@@ -287,6 +287,8 @@
                 "schedule": { "type": "string" },
                 "parallelism": { "type": "integer" },
                 "nodeSelector": { "type": "object" },
+                "podSecurityContext": { "type": "object" },
+                "containerSecurityContext": { "type": "object" },
                 "resources": {
                   "type": "object",
                   "additionalProperties": false,


### PR DESCRIPTION
- Removes nonexistent `securityContext` configuration, replaces with `podSecurityContext` and `containerSecurityContext`
- Allows different `securityContext` for service cronjobs