### PR TITLE
Custom affinities and tolerations

### DIFF
--- a/charts/frontend/templates/services-cron.yaml
+++ b/charts/frontend/templates/services-cron.yaml
@@ -105,26 +105,49 @@ spec:
             {{- end }}
             {{- end }}
           restartPolicy: OnFailure
-          {{- if or $job.nodeSelector $service.nodeSelector ($.Values.cronJobDefaults).nodeSelector }}
+          {{- if or $job.nodeSelector $service.nodeSelector ($.Values.cronJobDefaults).nodeSelector ($.Values.serviceDefaults).nodeSelector }}      
           nodeSelector:
             {{- if $job.nodeSelector }}
             {{- $job.nodeSelector | toYaml | nindent 12 }}
-            {{- else }}
-            {{- if ($.Values.cronJobDefaults).nodeSelector }}
+            {{- else if ($.Values.cronJobDefaults).nodeSelector }}
             {{- $.Values.cronJobDefaults.nodeSelector | toYaml | nindent 12 }}
-            {{- else }}
+            {{- else if $service.nodeSelector }}
             {{- $service.nodeSelector | toYaml | nindent 12 }}
+            {{- else if ($.Values.serviceDefaults).nodeSelector }}
+            {{- $.Values.serviceDefaults.nodeSelector | toYaml | nindent 12 }}
             {{- end }}
-            {{- end }}
+          {{- end }}
+          {{- if or $job.nodeSelector $service.nodeSelector ($.Values.cronJobDefaults).nodeSelector ($.Values.serviceDefaults).nodeSelector $job.tolerations $service.tolerations ($.Values.cronJobDefaults).tolerations ($.Values.serviceDefaults).tolerations }}
           tolerations:
             {{- if $job.nodeSelector }}
             {{- include "frontend.tolerations" $job.nodeSelector | nindent 12 }}
-            {{- else }}
-            {{- if ($.Values.cronJobDefaults).nodeSelector }}
+            {{- else if ($.Values.cronJobDefaults).nodeSelector }}
             {{- include "frontend.tolerations" $.Values.cronJobDefaults.nodeSelector | nindent 12 }}
-            {{- else }}
+            {{- else if $service.nodeSelector }}
             {{- include "frontend.tolerations" $service.nodeSelector | nindent 12 }}
+            {{- else if ($.Values.serviceDefaults).nodeSelector }}
+            {{- include "frontend.tolerations" $.Values.serviceDefaults.nodeSelector | nindent 12 }}
             {{- end }}
+            {{- if $job.tolerations }}
+            {{- $job.tolerations | toYaml | nindent 12 }}
+            {{- else if ($.Values.cronJobDefaults).tolerations }}
+            {{- $.Values.cronJobDefaults.tolerations | toYaml | nindent 12 }}
+            {{- else if $service.tolerations }}
+            {{- $service.tolerations | toYaml | nindent 12 }}
+            {{- else if ($.Values.serviceDefaults).tolerations }}
+            {{- $.Values.serviceDefaults.tolerations | toYaml | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- if or $job.affinity $service.affinity ($.Values.cronJobDefaults).affinity ($.Values.serviceDefaults).affinity }}
+          affinity:
+            {{- if $job.affinity }}
+            {{-  tpl ($job.affinity | toYaml ) (dict "Values" $.Values "Release" $.Release "serviceLabel" (printf "frontend-%s" $serviceName)) | nindent 12 }}
+            {{- else if ($.Values.cronJobDefaults).affinity }}
+            {{-  tpl ($.Values.cronJobDefaults.affinity | toYaml ) (dict "Values" $.Values "Release" $.Release "serviceLabel" (printf "frontend-%s" $serviceName)) | nindent 12 }}
+            {{- else if $service.affinity }}
+            {{-  tpl ($service.affinity | toYaml ) (dict "Values" $.Values "Release" $.Release "serviceLabel" (printf "frontend-%s" $serviceName)) | nindent 12 }}
+            {{- else if ($.Values.serviceDefaults).affinity }}
+            {{-  tpl ($.Values.serviceDefaults.affinity | toYaml ) (dict "Values" $.Values "Release" $.Release "serviceLabel" (printf "frontend-%s" $serviceName)) | nindent 12 }}
             {{- end }}
           {{- end }}
 ---

--- a/charts/frontend/templates/services-deployment.yaml
+++ b/charts/frontend/templates/services-deployment.yaml
@@ -1,8 +1,8 @@
-{{- range $index, $service := .Values.services }}
+{{- range $serviceName, $service := .Values.services }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $.Release.Name }}-{{ $index }}
+  name: {{ $.Release.Name }}-{{ $serviceName }}
   labels:
     {{- include "frontend.release_labels" $ | nindent 4 }}
     silta-frontend: service
@@ -15,12 +15,12 @@ spec:
   selector:
     matchLabels:
       {{- include "frontend.release_selector_labels" $ | nindent 6 }}
-      deployment: frontend-{{ $index }}
+      deployment: frontend-{{ $serviceName }}
   template:
     metadata:
       labels:
         {{- include "frontend.release_labels" $ | nindent 8 }}
-        deployment: frontend-{{ $index }}
+        deployment: frontend-{{ $serviceName }}
         silta-frontend: service
         {{- if $.Values.shell.enabled }}
         silta-ingress: allow
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       enableServiceLinks: false
       containers:
-      - name: {{ $index }}
+      - name: {{ $serviceName }}
         image: {{ $service.image | quote }}
         {{- if $service.containerSecurityContext }}
         securityContext:
@@ -43,7 +43,7 @@ spec:
         {{- end }}
         ports:
         - containerPort: {{ default $.Values.serviceDefaults.port $service.port }}
-          name: {{ $index }}
+          name: {{ $serviceName }}
         volumeMounts:
           {{- if $service.mounts }}
           {{- range $index, $mountName := $service.mounts }}
@@ -131,62 +131,31 @@ spec:
       {{- $nodeSelector := default $.Values.serviceDefaults.nodeSelector $service.nodeSelector }}
       {{- if $nodeSelector }}
       nodeSelector:
-        {{ $nodeSelector | toYaml | nindent 8 }}
+        {{- $nodeSelector | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if or $nodeSelector $service.tolerations $.Values.serviceDefaults.tolerations  }}
       tolerations:
-        {{ include "frontend.tolerations" $nodeSelector | nindent 8 }}
+        {{- include "frontend.tolerations" $nodeSelector | nindent 8 }}
+        {{- if $service.tolerations }}
+        {{- toYaml $service.tolerations | nindent 8 }}
+        {{- else if $.Values.serviceDefaults.tolerations }}
+        {{- toYaml $.Values.serviceDefaults.tolerations | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- if or $service.affinity $.Values.serviceDefaults.affinity }}
       affinity:
-        podAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          # Preferrably keep pods on the same node as the database.
-          - weight: 1
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: release
-                  operator: In
-                  values:
-                  - "{{ $.Release.Name }}"
-                - key: mariadb
-                  operator: In
-                  values:
-                  - mariadb
-              topologyKey: kubernetes.io/hostname
-          # Preferrably keep pods in the same zone as the database.
-          - weight: 1
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: release
-                  operator: In
-                  values:
-                  - "{{ $.Release.Name }}"
-                - key: mariadb
-                  operator: In
-                  values:
-                  - mariadb
-              topologyKey: topology.kubernetes.io/zone
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 10
-            podAffinityTerm:
-              topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchExpressions:
-                - key: release
-                  operator: In
-                  values:
-                  - "{{ $.Release.Name }}"
-                - key: deployment
-                  operator: In
-                  values:
-                  - frontend-{{ $index }}
+        {{- if $service.affinity }}
+        {{- tpl ( $service.affinity | toYaml ) (dict "Values" $.Values "Release" $.Release "serviceLabel" (printf "frontend-%s" $serviceName)) | nindent 8 }}
+        {{- else if $.Values.serviceDefaults.affinity }}
+        {{- tpl ( $.Values.serviceDefaults.affinity | toYaml ) (dict "Values" $.Values "Release" $.Release "serviceLabel" (printf "frontend-%s" $serviceName)) | nindent 8 }}
+        {{- end }}
       {{- end }}
 {{- if or $service.postupgrade $service.postinstall }}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ $.Release.Name }}-{{ $index }}-post-release"
+  name: "{{ $.Release.Name }}-{{ $serviceName }}-post-release"
   labels:
     {{- include "frontend.release_labels" $ | nindent 4 }}
   annotations:
@@ -206,7 +175,7 @@ spec:
       restartPolicy: Never
       enableServiceLinks: false
       containers:
-      - name: {{ $index }}
+      - name: {{ $serviceName }}
         image: {{ $service.image | quote }}
         command: ["/bin/bash", "-c"]
         args:
@@ -221,7 +190,7 @@ spec:
             {{- end }}
         volumeMounts:
           {{ if $service.mounts }}
-          {{- range $index, $mountName := $service.mounts }}
+          {{- range $serviceName, $mountName := $service.mounts }}
           {{ $mount := (index $.Values.mounts $mountName) }}
           {{- if eq $mount.enabled true }}
           - name: frontend-{{ $mountName }}
@@ -245,7 +214,7 @@ spec:
         {{- end }}
       volumes:
         {{ if $service.mounts }}
-        {{- range $index, $mountName := $service.mounts }}
+        {{- range $serviceName, $mountName := $service.mounts }}
         {{- $mount := (index $.Values.mounts $mountName) }}
         {{- if eq $mount.enabled true }}
         - name: frontend-{{ $mountName }}
@@ -283,14 +252,14 @@ spec:
 apiVersion: {{ include "frontend.autoscaling.api-version" $ | trim }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ $.Release.Name }}-{{ $index }}
+  name: {{ $.Release.Name }}-{{ $serviceName }}
   labels:
     {{- include "frontend.release_labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ $.Release.Name }}-{{ $index }}
+    name: {{ $.Release.Name }}-{{ $serviceName }}
   minReplicas: {{ default $.Values.serviceDefaults.autoscaling.minReplicas $service.autoscaling.minReplicas }}
   maxReplicas: {{ default $.Values.serviceDefaults.autoscaling.maxReplicas $service.autoscaling.maxReplicas }}
   metrics:

--- a/charts/frontend/values.schema.json
+++ b/charts/frontend/values.schema.json
@@ -287,6 +287,8 @@
                 "schedule": { "type": "string" },
                 "parallelism": { "type": "integer" },
                 "nodeSelector": { "type": "object" },
+                "tolerations": { "type": "array" },
+                "affinity": { "type": "object" },
                 "resources": {
                   "type": "object",
                   "additionalProperties": false,
@@ -321,6 +323,8 @@
             "type": "object",
             "additionalProperties": { "type": "string" }
           },
+          "tolerations": { "type": ["array", "null"] },
+          "affinity": { "type": ["object", "null"] },
           "containerSecurityContext": {
             "type": "object",
             "additionalProperties": false,
@@ -501,6 +505,12 @@
         "nodeSelector": {
           "type": "object",
           "additionalProperties": { "type": "string" }
+        },
+        "tolerations": { 
+          "type": ["array", "null"] 
+        },
+        "affinity": {
+          "type": ["object", "null"]
         }
       }
     },
@@ -531,7 +541,9 @@
         "nodeSelector": {
           "type": "object",
           "additionalProperties": { "type": "string" }
-        }
+        },
+        "tolerations": { "type": ["array", "null"] },
+        "affinity": { "type": ["object", "null"] }
       }
     },
     "shell": {

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -271,6 +271,8 @@ services: {}
   #      parallelism: 1
   #      nodeSelector:
   #        cloud.google.com/gke-nodepool: static-ip
+  #      tolerations: []
+  #      affinity: {}
   #      # Optionally override service resource requests
   #      resources:
   #        requests:
@@ -283,6 +285,8 @@ services: {}
 
   #   nodeSelector:
   #     cloud.google.com/gke-nodepool: static-ip
+  #   tolerations: []
+  #   affinity: {}
 
   #  nginx:
   #    denyDotFiles: true
@@ -374,7 +378,53 @@ serviceDefaults:
         targetAverageUtilization: 80
   # nodeSelector:
   #   cloud.google.com/gke-nodepool: static-ip
-
+  # tolerations: []
+  affinity:
+    podAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      # Preferrably keep pods on the same node as the database.
+      - weight: 1
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: release
+              operator: In
+              values:
+              - "{{ $.Release.Name }}"
+            - key: mariadb
+              operator: In
+              values:
+              - mariadb
+          topologyKey: kubernetes.io/hostname
+      # Preferrably keep pods in the same zone as the database.
+      - weight: 1
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: release
+              operator: In
+              values:
+              - "{{ $.Release.Name }}"
+            - key: mariadb
+              operator: In
+              values:
+              - mariadb
+          topologyKey: topology.kubernetes.io/zone
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 10
+        podAffinityTerm:
+          topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchExpressions:
+            - key: release
+              operator: In
+              values:
+              - "{{ $.Release.Name }}"
+            - key: deployment
+              operator: In
+              values:
+              - "{{ $.serviceLabel }}"
 # Provide defaults for all cron jobs. This will override serviceDefaults when defined.
 cronJobDefaults:
   # resources:
@@ -385,6 +435,8 @@ cronJobDefaults:
   #     memory: 122Mi
   # nodeSelector:
   #   cloud.google.com/gke-nodepool: static-ip
+  # tolerations: []
+  # affinity: {}
 
 # Override the default values of the MariaDB subchart.
 # These settings are optimised for development environments.


### PR DESCRIPTION
Allows definition of custom node and pod affinities, along with tolerations.
- Current service pod affinities moved from deployment template to chart values
- Current tolerations, created by inverse nodeSelector rules are kept, provides backwards compatibility with current `nodeSelector` rules

Changed service $index in deployment resource template to $serviceName to avoid confusion with mount iterator, just like cronjob template has. 

Testing done with `helm unittest` and manually, by defining `<service>.nodeSelector`, `<service>.tolerations`, `<service>.affinity`, `<service>.cron.nodeSelector`, `<service>.cron.tolerations`, and `<service>.cron.affinity` values in various combinations, confirming expected output with `helm template` command. 
