### PR TITLE
Connection limit annotation validation

### DIFF
--- a/charts/frontend/templates/checks.yaml
+++ b/charts/frontend/templates/checks.yaml
@@ -11,3 +11,12 @@
 {{- end }}
 {{- end }}
 {{- end }}
+{{- /* Ingress checks */ -}}
+{{- range $ingress_index, $ingress := $.Values.ingress }}
+{{- if and $ingress.extraAnnotations (hasKey $ingress.extraAnnotations "nginx.ingress.kubernetes.io/limit-connections") }}
+{{- $limit := int (get $ingress.extraAnnotations "nginx.ingress.kubernetes.io/limit-connections") }}
+{{- if gt $limit 65536 }}
+{{- fail "nginx.ingress.kubernetes.io/limit-connections cannot be greater than 65536" }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/frontend/tests/ingress_test.yaml
+++ b/charts/frontend/tests/ingress_test.yaml
@@ -1,6 +1,7 @@
 suite: Site ingress
 templates:
   - ingress.yaml
+  - checks.yaml
 tests:
   - it: is a ingress
     template: ingress.yaml
@@ -285,3 +286,40 @@ tests:
         equal:
           path: metadata.annotations['kubernetes.io/ingress.global-static-ip-name']
           value: 'baz'
+
+  - it: prevents limit connections above 65536 for default ingress
+    template: checks.yaml
+    set:
+      ingress:
+        default:
+          extraAnnotations:
+            'nginx.ingress.kubernetes.io/limit-connections': '65537'
+    asserts:
+      - failedTemplate:
+          errorMessage: "nginx.ingress.kubernetes.io/limit-connections cannot be greater than 65536"
+
+  - it: allows limit connections above 65536 for default ingress
+    template: checks.yaml
+    set:
+      ingress:
+        default:
+          extraAnnotations:
+            'nginx.ingress.kubernetes.io/limit-connections': '65536'
+    asserts:
+      - notFailedTemplate:
+          errorMessage: "nginx.ingress.kubernetes.io/limit-connections cannot be greater than 65536"
+
+  - it: prevents limit connections above 65536 for enabled exposeDomains ingress
+    template: checks.yaml
+    set:
+      exposeDomains:
+        bar:
+          hostname: foo.bar
+          ingress: baz
+      ingress:
+        baz:
+          extraAnnotations:
+            'nginx.ingress.kubernetes.io/limit-connections': '65537'
+    asserts:
+      - failedTemplate:
+          errorMessage: "nginx.ingress.kubernetes.io/limit-connections cannot be greater than 65536"


### PR DESCRIPTION
Prevents nginx configuration emergency failure when setting connection limit above 65536

Testing:
```yaml
ingress:
  default:
    extraAnnotations:
      nginx.ingress.kubernetes.io/limit-connections: "65537"
```