### PR TITLE
Custom clusterIssuer support; Old cert-manager api deprecation

### DIFF
--- a/charts/frontend/templates/_helpers.tpl
+++ b/charts/frontend/templates/_helpers.tpl
@@ -202,14 +202,6 @@ rsync -az /values_mounts/ /backups/current/
 {{- end }}
 {{- end }}
 
-{{- define "cert-manager.api-version" }}
-{{- if ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
-cert-manager.io/v1
-{{- else }}
-certmanager.k8s.io/v1alpha1
-{{- end }}
-{{- end }}
-
 {{- define "ingress.api-version" }}
 {{- if and ( ge $.Capabilities.KubeVersion.Major "1") ( ge $.Capabilities.KubeVersion.Minor "18" ) }}
 networking.k8s.io/v1

--- a/charts/frontend/templates/certificate.yaml
+++ b/charts/frontend/templates/certificate.yaml
@@ -1,109 +1,7 @@
 {{- $context_ingress := .Values.ingress.default }}
 {{- $context_ssl := .Values.ssl }}
 {{- if $context_ingress.tls }}
-{{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-apiVersion: {{ include "cert-manager.api-version" . | trim }}
-kind: Certificate
-metadata:
-  name: {{ .Release.Name }}-crt
-  annotations:
-    cert-manager.io/issue-temporary-certificate: "true"
-    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-nginx"
-  labels:
-    {{- include "frontend.release_labels" . | nindent 4 }}
-spec:
-  secretName: {{ .Release.Name }}-tls
-  dnsNames:
-  - {{ template "frontend.domain" . }}
-  issuerRef:
-    name: {{ $context_ssl.issuer }}
-    kind: ClusterIssuer
-{{- if eq ( include "cert-manager.api-version" . | trim ) "certmanager.k8s.io/v1alpha1" }}
-  acme:
-    config:
-      - http01:
-          ingress: {{ .Release.Name }}-nginx
-        domains:
-          - {{ template "frontend.domain" . }}
-{{- end }}
-  privateKey:
-    rotationPolicy: "Always"
----
-{{- range $index, $prefix := .Values.domainPrefixes }}
-{{- $params := dict "prefix" $prefix }}
-apiVersion: {{ include "cert-manager.api-version" $ | trim }}
-kind: Certificate
-metadata:
-  name: {{ $.Release.Name }}-crt-p{{ $index }}
-  annotations:
-    cert-manager.io/issue-temporary-certificate: "true" 
-    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-nginx"
-  labels:
-    {{- include "frontend.release_labels" $ | nindent 4 }}
-spec:
-  secretName: {{ $.Release.Name }}-tls-p{{ $index }}
-  dnsNames:
-  - '{{ template "frontend.domain" (merge $params $ ) }}'
-  issuerRef:
-    name: {{ $context_ssl.issuer }}
-    kind: ClusterIssuer
-{{- if eq ( include "cert-manager.api-version" $ | trim ) "certmanager.k8s.io/v1alpha1" }}
-  acme:
-    config:
-      - http01:
-          ingress: {{ $.Release.Name }}-nginx
-        domains:
-          - '{{ template "frontend.domain" (merge $params $ ) }}'
-{{- end }}
-  privateKey:
-    rotationPolicy: "Always"
----
-{{- end }}
-
-{{- else if eq $context_ssl.issuer "selfsigned" }}
-apiVersion: {{ include "cert-manager.api-version" . | trim }}
-kind: Certificate
-metadata:
-  name: {{ .Release.Name }}-crt
-  labels:
-    {{- include "frontend.release_labels" . | nindent 4 }}
-spec:
-  secretName: {{ .Release.Name }}-tls
-  duration: 2160h
-  renewBefore: 150h 
-  commonName: {{ template "frontend.domain" . }}
-  dnsNames:
-  - {{ template "frontend.domain" . }}
-  issuerRef:
-    name: {{ $context_ssl.issuer }}
-    kind: ClusterIssuer
-  privateKey:
-    rotationPolicy: "Always"
----
-{{- range $index, $prefix := .Values.domainPrefixes }}
-{{- $params := dict "prefix" $prefix  -}}
-apiVersion: {{ include "cert-manager.api-version" $ | trim }}
-kind: Certificate
-metadata:
-  name: {{ $.Release.Name }}-crt-p{{ $index }}
-  labels:
-    {{- include "frontend.release_labels" $ | nindent 4 }}
-spec:
-  secretName: {{ $.Release.Name }}-tls-p{{ $index }}
-  duration: 2160h
-  renewBefore: 150h
-  commonName: {{ include "frontend.domain" (merge $params $ ) }}
-  dnsNames:
-    - '{{ include "frontend.domain" (merge $params $ ) }}'
-  issuerRef:
-    name: {{ $context_ssl.issuer }}
-    kind: ClusterIssuer
-  privateKey:
-    rotationPolicy: "Always"
----
-{{- end }}
-
-{{- else if eq $context_ssl.issuer "custom" }}
+{{- if eq $context_ssl.issuer "custom" }}
 {{- if not $context_ssl.existingTLSSecret }}
 apiVersion: v1
 kind: Secret
@@ -132,65 +30,72 @@ data:
 ---
 {{- end }}
 {{- end }}
-{{- end }}
-
-# Certificates for exposeDomains 
-
-{{- range $index, $domain := .Values.exposeDomains }}
-{{- $domain := merge $domain $.Values.exposeDomainsDefaults }}
-{{- if $domain.ssl }}
-{{- if $domain.ssl.enabled }}
-{{- if has $domain.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-apiVersion: {{ include "cert-manager.api-version" $ | trim }}
+{{- else }}
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ $.Release.Name }}-crt-{{ $index }}
+  name: {{ .Release.Name }}-crt
+  {{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
   annotations:
     cert-manager.io/issue-temporary-certificate: "true"
-    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-nginx-{{ $domain.ingress }}"
+    acme.cert-manager.io/http01-override-ingress-name: "{{ .Release.Name }}-nginx"
+  {{- end }}
   labels:
-    {{- include "frontend.release_labels" $ | nindent 4 }}
+    {{- include "frontend.release_labels" . | nindent 4 }}
 spec:
-  secretName: {{ $.Release.Name }}-tls-{{ $index }}
+  secretName: {{ .Release.Name }}-tls
+  {{- if eq $context_ssl.issuer "selfsigned" }}
+  duration: 2160h
+  renewBefore: 150h
+  commonName: {{ template "frontend.domain" . }}
+  {{- end }}
   dnsNames:
-  - {{ $domain.hostname }}
+  - {{ template "frontend.domain" . }}
   issuerRef:
-    name: {{ $domain.ssl.issuer }}
+    name: {{ $context_ssl.issuer }}
     kind: ClusterIssuer
-{{- if eq ( include "cert-manager.api-version" $ | trim ) "certmanager.k8s.io/v1alpha1" }}
-  acme:
-    config:
-      - http01:
-          ingress: {{ $.Release.Name }}-nginx-{{ $domain.ingress }}
-        domains:
-          - {{ $domain.hostname }}
-{{- end }}
   privateKey:
     rotationPolicy: "Always"
 ---
-
-{{- else if eq $domain.ssl.issuer "selfsigned" }}
-apiVersion: {{ include "cert-manager.api-version" $ | trim }}
+{{- range $index, $prefix := .Values.domainPrefixes }}
+{{- $params := dict "prefix" $prefix }}
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ $.Release.Name }}-crt-{{ $index }}
+  name: {{ $.Release.Name }}-crt-p{{ $index }}
+  {{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
+  annotations:
+    cert-manager.io/issue-temporary-certificate: "true"
+    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-nginx"
+  {{- end }}
   labels:
     {{- include "frontend.release_labels" $ | nindent 4 }}
 spec:
-  secretName: {{ $.Release.Name }}-tls-{{ $index }}
+  secretName: {{ $.Release.Name }}-tls-p{{ $index }}
+  {{- if eq $context_ssl.issuer "selfsigned" }}
   duration: 2160h
-  renewBefore: 150h 
-  commonName: {{ $domain.hostname }}
+  renewBefore: 150h
+  commonName: {{ include "frontend.domain" (merge $params $) }}
+  {{- end }}
   dnsNames:
-  - {{ $domain.hostname }}
+  - '{{ template "frontend.domain" (merge $params $) }}'
   issuerRef:
-    name: {{ $domain.ssl.issuer }}
+    name: {{ $context_ssl.issuer }}
     kind: ClusterIssuer
   privateKey:
     rotationPolicy: "Always"
 ---
+{{- end }}
+{{- end }}
+{{- end }}
 
-{{- else if eq $domain.ssl.issuer "custom" }}
+# Certificates for exposeDomains
+
+{{- range $index, $domain := .Values.exposeDomains }}
+{{- $domain := mergeOverwrite ($.Values.exposeDomainsDefaults | toYaml | fromYaml) $domain }}
+{{- if $domain.ssl }}
+{{- if $domain.ssl.enabled }}
+{{- if eq $domain.ssl.issuer "custom" }}
 {{- if not $domain.ssl.existingTLSSecret }}
 apiVersion: v1
 kind: Secret
@@ -207,7 +112,33 @@ data:
   tls.key: {{ $domain.ssl.key | default "" | b64enc }}
 ---
 {{- end }}
-{{- end }}
+{{- else }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $.Release.Name }}-crt-{{ $index }}
+  {{- if has $domain.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
+  annotations:
+    cert-manager.io/issue-temporary-certificate: "true"
+    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-nginx-{{ $domain.ingress }}"
+  {{- end }}
+  labels:
+    {{- include "frontend.release_labels" $ | nindent 4 }}
+spec:
+  secretName: {{ $.Release.Name }}-tls-{{ $index }}
+  {{- if eq $domain.ssl.issuer "selfsigned" }}
+  duration: 2160h
+  renewBefore: 150h
+  commonName: {{ $domain.hostname }}
+  {{- end }}
+  dnsNames:
+  - {{ $domain.hostname }}
+  issuerRef:
+    name: {{ $domain.ssl.issuer }}
+    kind: ClusterIssuer
+  privateKey:
+    rotationPolicy: "Always"
+---
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/frontend/templates/ingress.yaml
+++ b/charts/frontend/templates/ingress.yaml
@@ -15,11 +15,7 @@ metadata:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- end }}
     {{- if $ingress.tls }}
-    {{- if eq ( include "cert-manager.api-version" . | trim ) "cert-manager.io/v1" }}
     acme.cert-manager.io/http01-edit-in-place: "true"
-    {{- else }}
-    certmanager.k8s.io/acme-http01-edit-in-place: "true"
-    {{- end }}
     {{- if eq $ingress.type "traefik" }}
     traefik.ingress.kubernetes.io/frontend-entry-points: "http,https"
     {{- end }}
@@ -184,11 +180,7 @@ metadata:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- end }}
     {{- if $ingress.tls }}
-    {{- if eq ( include "cert-manager.api-version" $ | trim ) "cert-manager.io/v1" }}
     acme.cert-manager.io/http01-edit-in-place: "true"
-    {{- else }}
-    certmanager.k8s.io/acme-http01-edit-in-place: "true"
-    {{- end }}
     {{- if eq $ingress.type "traefik" }}
     traefik.ingress.kubernetes.io/frontend-entry-points: "http,https"
     {{- end }}

--- a/charts/frontend/tests/certificate_test.yaml
+++ b/charts/frontend/tests/certificate_test.yaml
@@ -1,0 +1,437 @@
+suite: Site certificate
+templates:
+  - certificate.yaml
+tests:
+
+  # --- Main domain: letsencrypt ---
+
+  - it: letsencrypt emits a v1 Certificate
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Certificate
+      - documentIndex: 0
+        equal:
+          path: apiVersion
+          value: 'cert-manager.io/v1'
+
+  - it: letsencrypt Certificate has ACME annotations
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: metadata.annotations['cert-manager.io/issue-temporary-certificate']
+          value: 'true'
+      - documentIndex: 0
+        equal:
+          path: metadata.annotations['acme.cert-manager.io/http01-override-ingress-name']
+          value: 'RELEASE-NAME-nginx'
+
+  - it: letsencrypt Certificate has correct issuerRef
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.name
+          value: letsencrypt
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.kind
+          value: ClusterIssuer
+
+  - it: letsencrypt Certificate has no duration or commonName
+    asserts:
+      - documentIndex: 0
+        notExists:
+          path: spec.duration
+      - documentIndex: 0
+        notExists:
+          path: spec.commonName
+
+  - it: letsencrypt Certificate has privateKey rotationPolicy
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.privateKey.rotationPolicy
+          value: Always
+
+  # --- Main domain: letsencrypt-staging ---
+
+  - it: letsencrypt-staging emits a Certificate with ACME annotations
+    set:
+      ssl.issuer: letsencrypt-staging
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Certificate
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.name
+          value: letsencrypt-staging
+      - documentIndex: 0
+        equal:
+          path: metadata.annotations['cert-manager.io/issue-temporary-certificate']
+          value: 'true'
+
+  # --- Main domain: selfsigned ---
+
+  - it: selfsigned emits a Certificate
+    set:
+      ssl.issuer: selfsigned
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Certificate
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.name
+          value: selfsigned
+
+  - it: selfsigned Certificate has duration and renewBefore
+    set:
+      ssl.issuer: selfsigned
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.duration
+          value: 2160h
+      - documentIndex: 0
+        equal:
+          path: spec.renewBefore
+          value: 150h
+
+  - it: selfsigned Certificate has commonName set to the domain
+    set:
+      ssl.issuer: selfsigned
+      environmentName: myenv
+      projectName: myproject
+      clusterDomain: example.com
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.commonName
+          value: myenv.myproject.example.com
+
+  - it: selfsigned Certificate has no ACME annotations
+    set:
+      ssl.issuer: selfsigned
+    asserts:
+      - documentIndex: 0
+        notExists:
+          path: metadata.annotations
+
+  # --- Main domain: custom ---
+
+  - it: custom emits a Secret
+    set:
+      ssl.issuer: custom
+      ssl.ca: dGVzdA==
+      ssl.crt: dGVzdA==
+      ssl.key: dGVzdA==
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Secret
+      - documentIndex: 0
+        equal:
+          path: type
+          value: kubernetes.io/tls
+
+  - it: custom with existingTLSSecret emits no resources
+    set:
+      ssl.issuer: custom
+      ssl.existingTLSSecret: my-existing-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # --- Main domain: arbitrary ClusterIssuer ---
+
+  - it: arbitrary issuer emits a Certificate
+    set:
+      ssl.issuer: my-cluster-issuer
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Certificate
+      - documentIndex: 0
+        equal:
+          path: apiVersion
+          value: 'cert-manager.io/v1'
+
+  - it: arbitrary issuer Certificate has correct issuerRef
+    set:
+      ssl.issuer: my-cluster-issuer
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.name
+          value: my-cluster-issuer
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.kind
+          value: ClusterIssuer
+
+  - it: arbitrary issuer Certificate has no ACME annotations
+    set:
+      ssl.issuer: my-cluster-issuer
+    asserts:
+      - documentIndex: 0
+        notExists:
+          path: metadata.annotations
+
+  - it: arbitrary issuer Certificate has no duration or commonName
+    set:
+      ssl.issuer: my-cluster-issuer
+    asserts:
+      - documentIndex: 0
+        notExists:
+          path: spec.duration
+      - documentIndex: 0
+        notExists:
+          path: spec.commonName
+
+  - it: arbitrary issuer Certificate has privateKey rotationPolicy
+    set:
+      ssl.issuer: my-cluster-issuer
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.privateKey.rotationPolicy
+          value: Always
+
+  # --- domainPrefixes ---
+
+  - it: letsencrypt with domainPrefixes emits prefix Certificates with ACME annotations
+    set:
+      domainPrefixes: ['www']
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: Certificate
+      - documentIndex: 1
+        equal:
+          path: metadata.annotations['cert-manager.io/issue-temporary-certificate']
+          value: 'true'
+      - documentIndex: 1
+        equal:
+          path: spec.issuerRef.name
+          value: letsencrypt
+
+  - it: selfsigned with domainPrefixes emits prefix Certificates with duration
+    set:
+      ssl.issuer: selfsigned
+      domainPrefixes: ['www']
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: Certificate
+      - documentIndex: 1
+        equal:
+          path: spec.duration
+          value: 2160h
+      - documentIndex: 1
+        notExists:
+          path: metadata.annotations
+
+  - it: arbitrary issuer with domainPrefixes emits plain prefix Certificates
+    set:
+      ssl.issuer: my-cluster-issuer
+      domainPrefixes: ['www']
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: Certificate
+      - documentIndex: 1
+        equal:
+          path: spec.issuerRef.name
+          value: my-cluster-issuer
+      - documentIndex: 1
+        notExists:
+          path: metadata.annotations
+      - documentIndex: 1
+        notExists:
+          path: spec.duration
+
+  # --- exposeDomains: ssl.enabled: false ---
+
+  - it: exposeDomain with ssl.enabled false emits no certificate for that domain
+    set:
+      exposeDomains:
+        nodomain:
+          hostname: insecure.example.com
+          ssl:
+            enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: exposeDomain with ssl.enabled false does not override default true on other domains
+    set:
+      exposeDomains:
+        nodomain:
+          hostname: insecure.example.com
+          ssl:
+            enabled: false
+        secure:
+          hostname: secure.example.com
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 1
+        equal:
+          path: spec.dnsNames[0]
+          value: secure.example.com
+
+  # --- exposeDomains: default issuer (letsencrypt) ---
+
+  - it: exposeDomain with default issuer emits a Certificate with ACME annotations
+    set:
+      exposeDomains:
+        foo:
+          hostname: foo.example.com
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: Certificate
+      - documentIndex: 1
+        equal:
+          path: metadata.annotations['cert-manager.io/issue-temporary-certificate']
+          value: 'true'
+      - documentIndex: 1
+        equal:
+          path: metadata.annotations['acme.cert-manager.io/http01-override-ingress-name']
+          value: 'RELEASE-NAME-nginx-default'
+      - documentIndex: 1
+        equal:
+          path: spec.dnsNames[0]
+          value: foo.example.com
+      - documentIndex: 1
+        equal:
+          path: spec.issuerRef.name
+          value: letsencrypt
+
+  # --- exposeDomains: selfsigned issuer ---
+
+  - it: exposeDomain with selfsigned issuer emits Certificate with duration and commonName
+    set:
+      exposeDomains:
+        foo:
+          hostname: foo.example.com
+          ssl:
+            issuer: selfsigned
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: Certificate
+      - documentIndex: 1
+        equal:
+          path: spec.duration
+          value: 2160h
+      - documentIndex: 1
+        equal:
+          path: spec.renewBefore
+          value: 150h
+      - documentIndex: 1
+        equal:
+          path: spec.commonName
+          value: foo.example.com
+      - documentIndex: 1
+        notExists:
+          path: metadata.annotations
+
+  # --- exposeDomains: custom issuer ---
+
+  - it: exposeDomain with custom issuer emits a Secret
+    set:
+      exposeDomains:
+        foo:
+          hostname: foo.example.com
+          ssl:
+            issuer: custom
+            crt: dGVzdA==
+            key: dGVzdA==
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: Secret
+      - documentIndex: 1
+        equal:
+          path: type
+          value: kubernetes.io/tls
+
+  - it: exposeDomain with custom issuer and existingTLSSecret emits no Secret
+    set:
+      exposeDomains:
+        foo:
+          hostname: foo.example.com
+          ssl:
+            issuer: custom
+            existingTLSSecret: my-tls-secret
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  # --- exposeDomains: arbitrary ClusterIssuer ---
+
+  - it: exposeDomain with arbitrary issuer emits a plain Certificate
+    set:
+      exposeDomains:
+        foo:
+          hostname: foo.example.com
+          ssl:
+            issuer: my-cluster-issuer
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: Certificate
+      - documentIndex: 1
+        equal:
+          path: apiVersion
+          value: 'cert-manager.io/v1'
+      - documentIndex: 1
+        equal:
+          path: spec.issuerRef.name
+          value: my-cluster-issuer
+      - documentIndex: 1
+        equal:
+          path: spec.issuerRef.kind
+          value: ClusterIssuer
+
+  - it: exposeDomain with arbitrary issuer Certificate has no ACME annotations
+    set:
+      exposeDomains:
+        foo:
+          hostname: foo.example.com
+          ssl:
+            issuer: my-cluster-issuer
+    asserts:
+      - documentIndex: 1
+        notExists:
+          path: metadata.annotations
+
+  - it: exposeDomain with arbitrary issuer Certificate has no duration or commonName
+    set:
+      exposeDomains:
+        foo:
+          hostname: foo.example.com
+          ssl:
+            issuer: my-cluster-issuer
+    asserts:
+      - documentIndex: 1
+        notExists:
+          path: spec.duration
+      - documentIndex: 1
+        notExists:
+          path: spec.commonName
+
+  - it: exposeDomain with arbitrary issuer Certificate has privateKey rotationPolicy
+    set:
+      exposeDomains:
+        foo:
+          hostname: foo.example.com
+          ssl:
+            issuer: my-cluster-issuer
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.privateKey.rotationPolicy
+          value: Always


### PR DESCRIPTION
- Custom clusterIssuer support, certificate template refactor
- Old cert-manager api depreciation (`certmanager.k8s.io/v1alpha1`, [depreciated in v0.11](https://cert-manager.io/docs/releases/release-notes/release-notes-0.11/).
