### PR TITLE
Workaround for traefik double-hypen issue

### DIFF
--- a/charts/frontend/templates/ingress-mw.yaml
+++ b/charts/frontend/templates/ingress-mw.yaml
@@ -4,7 +4,7 @@
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: {{ $.Release.Name }}-rl
+  name: {{ $.Release.Name | replace "--" "-" }}-rl
   labels:
     {{- include "frontend.release_labels" $ | nindent 4 }}
 spec:
@@ -31,7 +31,7 @@ spec:
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: {{ $.Release.Name }}-rl-{{ $ingress_index }}
+  name: {{ $.Release.Name | replace "--" "-" }}-rl-{{ $ingress_index }}
   labels:
     {{- include "frontend.release_labels" $ | nindent 4 }}
 spec:

--- a/charts/frontend/templates/ingress.yaml
+++ b/charts/frontend/templates/ingress.yaml
@@ -70,7 +70,7 @@ metadata:
     {{- if $ingress.extraAnnotations }}
     {{- $ingress.extraAnnotations | toYaml | nindent 4 }}
     {{- if eq ( include "silta-cluster.traefik3.enabled" $ ) "true" }}
-    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-{{ $.Release.Name }}-rl@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-{{ $.Release.Name | replace "--" "-" }}-rl@kubernetescrd
     {{- end }}
     {{- end }}
 
@@ -239,7 +239,7 @@ metadata:
     {{- if $ingress.extraAnnotations }}
     {{- $ingress.extraAnnotations | toYaml | nindent 4 }}
     {{- if eq ( include "silta-cluster.traefik3.enabled" $ ) "true" }}
-    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-{{ $.Release.Name }}-rl@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-{{ $.Release.Name | replace "--" "-" }}-rl@kubernetescrd
     {{- end }}
     {{- end }}
 

--- a/charts/frontend/tests/ingress_test.yaml
+++ b/charts/frontend/tests/ingress_test.yaml
@@ -407,6 +407,23 @@ tests:
       - failedTemplate:
           errorMessage: "nginx.ingress.kubernetes.io/limit-connections cannot be greater than 65536"
 
+  - it: normalizes double dashes in traefik3 middleware resource name
+    template: ingress-mw.yaml
+    capabilities:
+      apiVersions:
+        - traefik.io/v1alpha1
+    release:
+      name: foo--bar
+    set:
+      ingress:
+        default:
+          type: traefik
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: foo-bar-rl
+
   - it: uses default TLS secret when ssl.existingTLSSecret is not defined
     template: ingress.yaml
     asserts:


### PR DESCRIPTION
Traefik has issue with middleware names containing double dashes: https://community.traefik.io/t/problem-with-multiple-dash-in-middleware-annotation/18997/3

This is a workaround that replaces double dashes (`--`) in release name to a single dash (`-`).